### PR TITLE
feat: full workspace creation with route, menu, and default screen

### DIFF
--- a/internal/commands/workspace.go
+++ b/internal/commands/workspace.go
@@ -173,13 +173,31 @@ func runWorkspaceCreate(cmd *cobra.Command, flags workspaceCreateFlags) error {
 		return fmt.Errorf("failed to find Page Template: %w", err)
 	}
 
+	headingComponentSysID, err := lookupRecordSysID(ctx, sdkClient, "sys_ux_macroponent", "name=Heading")
+	if err != nil {
+		return fmt.Errorf("failed to find Heading component: %w", err)
+	}
+
+	composition := fmt.Sprintf(`[{
+		"definition": {"id": "%s", "type": "MACROPONENT"},
+		"elementId": "heading_1",
+		"elementLabel": "Heading 1",
+		"propertyValues": {
+			"label": {"type": "JSON_LITERAL", "value": "Welcome to %s"},
+			"variant": {"type": "JSON_LITERAL", "value": "header-primary"},
+			"level": {"type": "JSON_LITERAL", "value": "1"}
+		},
+		"slot": null,
+		"styles": null
+	}]`, headingComponentSysID, flags.name)
+
 	customMacroponent, err := sdkClient.CreateRecord(ctx, "sys_ux_macroponent", map[string]interface{}{
 		"name":                    "Home",
 		"extends":                 pageTemplateSysID,
 		"category":                "page",
 		"schema_version":          "1.0.0",
-		"layout":                  `{"default":{"children":null,"isInline":null,"items":[],"root":null,"rules":null,"styles":{"flex-direction":"column","height":"100%"},"templateId":"5832fd4d53c31010e6bcddeeff7b12db","type":"flex"},"version":"3.0.0"}`,
-		"composition":             "[]",
+		"layout":                  `{"default":{"children":null,"isInline":null,"items":[{"element_id":"heading_1","styles":{}}],"root":null,"rules":null,"styles":{"flex-direction":"column","height":"100%"},"templateId":"5832fd4d53c31010e6bcddeeff7b12db","type":"flex"},"version":"3.0.0"}`,
+		"composition":             composition,
 		"data":                    "[]",
 		"props":                   "[{\"description\":null,\"fieldType\":\"string\",\"label\":\"sysId\",\"mandatory\":false,\"name\":\"sysId\",\"readOnly\":true,\"selectable\":false,\"typeMetadata\":null,\"valueType\":\"string\"}]",
 		"internal_event_mappings": "{}",

--- a/internal/commands/workspace.go
+++ b/internal/commands/workspace.go
@@ -166,12 +166,47 @@ func runWorkspaceCreate(cmd *cobra.Command, flags workspaceCreateFlags) error {
 	}
 	screenTypeSysID := getString(screenType, "sys_id")
 
-	// ─── Step 6: Create default Home screen ────────────────────────────
+	// ─── Step 6: Create custom Home macroponent ────────────────────────
+	// The screen needs a custom macroponent extending Page Template
+	pageTemplateSysID, err := lookupRecordSysID(ctx, sdkClient, "sys_ux_macroponent", "name=Page Template")
+	if err != nil {
+		return fmt.Errorf("failed to find Page Template: %w", err)
+	}
+
+	customMacroponent, err := sdkClient.CreateRecord(ctx, "sys_ux_macroponent", map[string]interface{}{
+		"name":                    "Home",
+		"extends":                 pageTemplateSysID,
+		"category":                "page",
+		"schema_version":          "1.0.0",
+		"layout":                  `{"default":{"children":null,"isInline":null,"items":[],"root":null,"rules":null,"styles":{"flex-direction":"column","height":"100%"},"templateId":"5832fd4d53c31010e6bcddeeff7b12db","type":"flex"},"version":"3.0.0"}`,
+		"composition":             "[]",
+		"data":                    "[]",
+		"props":                   "[{\"description\":null,\"fieldType\":\"string\",\"label\":\"sysId\",\"mandatory\":false,\"name\":\"sysId\",\"readOnly\":true,\"selectable\":false,\"typeMetadata\":null,\"valueType\":\"string\"}]",
+		"internal_event_mappings": "{}",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create home macroponent: %w", err)
+	}
+	customMacroponentSysID := getString(customMacroponent, "sys_id")
+
+	macroponentConfig := `{
+		"bare": {"type": "JSON_LITERAL", "value": true},
+		"headerLevel": {"type": "JSON_LITERAL", "value": "1"},
+		"headingOnlyVisibleToScreenReaders": {"type": "JSON_LITERAL", "value": false},
+		"interceptNotifications": {"type": "JSON_LITERAL", "value": false},
+		"label": {"type": "TRANSLATION_LITERAL", "value": {"code": null, "comment": "", "message": ""}},
+		"propagateNotifications": {"type": "JSON_LITERAL", "value": false},
+		"scrollable": {"type": "JSON_LITERAL", "value": "y"},
+		"sysId": {"type": "JSON_LITERAL", "value": ""}
+	}`
+
 	_, err = sdkClient.CreateRecord(ctx, "sys_ux_screen", map[string]interface{}{
-		"name":               "Default Home",
+		"name":               "Home default",
 		"app_config":         workspaceSysID,
 		"screen_type":        screenTypeSysID,
 		"parent_macroponent": appShellSysID,
+		"macroponent":        customMacroponentSysID,
+		"macroponent_config": macroponentConfig,
 		"active":             true,
 		"order":              0,
 	})

--- a/internal/commands/workspace.go
+++ b/internal/commands/workspace.go
@@ -61,6 +61,7 @@ This command creates:
   - sys_ux_registry_m2m_category (registers in Workspaces menu)
   - sys_ux_screen_type (Home screen collection)
   - sys_ux_screen (Default Home screen)
+  - sys_ux_app_route (maps /home to the Home screen)
 
 After creation, open the workspace from the Workspaces menu in the
 Unified Navigator, or visit: /now/<path>/home
@@ -158,7 +159,7 @@ func runWorkspaceCreate(cmd *cobra.Command, flags workspaceCreateFlags) error {
 
 	// ─── Step 5: Create Home screen type ───────────────────────────────
 	screenType, err := sdkClient.CreateRecord(ctx, "sys_ux_screen_type", map[string]interface{}{
-		"name": flags.name + " Home",
+		"name": "Home",
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create screen type: %w", err)
@@ -176,6 +177,19 @@ func runWorkspaceCreate(cmd *cobra.Command, flags workspaceCreateFlags) error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create default screen: %w", err)
+	}
+
+	// ─── Step 7: Create home route ─────────────────────────────────────
+	_, err = sdkClient.CreateRecord(ctx, "sys_ux_app_route", map[string]interface{}{
+		"name":               "Home",
+		"route_type":         "home",
+		"app_config":         workspaceSysID,
+		"screen_type":        screenTypeSysID,
+		"parent_macroponent": appShellSysID,
+		"order":              0,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create home route: %w", err)
 	}
 
 	result := map[string]any{

--- a/internal/commands/workspace.go
+++ b/internal/commands/workspace.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strings"
+	"unicode"
 
 	"github.com/jacebenson/jsn/internal/appctx"
 	"github.com/jacebenson/jsn/internal/output"
@@ -51,7 +53,17 @@ func newWorkspaceCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new workspace (sys_ux_app_config)",
-		Long: `Create a new Configurable Workspace by creating a sys_ux_app_config record.
+		Long: `Create a new Configurable Workspace with all required artifacts.
+
+This command creates:
+  - sys_ux_app_config (workspace configuration)
+  - sys_ux_page_registry (URL route and app shell)
+  - sys_ux_registry_m2m_category (registers in Workspaces menu)
+  - sys_ux_screen_type (Home screen collection)
+  - sys_ux_screen (Default Home screen)
+
+After creation, open the workspace from the Workspaces menu in the
+Unified Navigator, or visit: /now/<path>/home
 
 Examples:
   jsn workspace create --name "My Workspace"
@@ -83,34 +95,104 @@ func runWorkspaceCreate(cmd *cobra.Command, flags workspaceCreateFlags) error {
 
 	outputWriter := appCtx.Output.(*output.Writer)
 	sdkClient := appCtx.SDK.(*sdk.Client)
+	ctx := cmd.Context()
 
-	data := map[string]interface{}{
+	// ─── Step 1: Create workspace config ────────────────────────────────
+	appConfigData := map[string]interface{}{
 		"name":   flags.name,
 		"active": flags.active,
 	}
 	if flags.description != "" {
-		data["description"] = flags.description
+		appConfigData["description"] = flags.description
 	}
 
-	record, err := sdkClient.CreateRecord(cmd.Context(), "sys_ux_app_config", data)
+	appConfig, err := sdkClient.CreateRecord(ctx, "sys_ux_app_config", appConfigData)
 	if err != nil {
-		return fmt.Errorf("failed to create workspace: %w", err)
+		return fmt.Errorf("failed to create workspace config: %w", err)
+	}
+	workspaceSysID := getString(appConfig, "sys_id")
+
+	// ─── Step 2: Look up default workspace references ───────────────────
+	appShellSysID, err := lookupRecordSysID(ctx, sdkClient, "sys_ux_macroponent", "name=Workspace App Shell")
+	if err != nil {
+		return fmt.Errorf("failed to find Workspace App Shell: %w", err)
 	}
 
-	sysID := getString(record, "sys_id")
+	parentAppSysID, err := lookupRecordSysID(ctx, sdkClient, "sys_ux_app", "name=Unified Navigation app shell")
+	if err != nil {
+		return fmt.Errorf("failed to find Unified Navigation app shell: %w", err)
+	}
+
+	workspaceCategorySysID, err := lookupRecordSysID(ctx, sdkClient, "sys_ux_experience_category", "name=Workspace")
+	if err != nil {
+		return fmt.Errorf("failed to find Workspace experience category: %w", err)
+	}
+
+	// ─── Step 3: Create page registry (URL route) ──────────────────────
+	path := slugify(flags.name)
+	registryData := map[string]interface{}{
+		"title":             flags.name,
+		"path":              path,
+		"active":            flags.active,
+		"admin_panel":       workspaceSysID,
+		"admin_panel_table": "sys_ux_app_config",
+		"parent_app":        parentAppSysID,
+		"root_macroponent":  appShellSysID,
+	}
+
+	registry, err := sdkClient.CreateRecord(ctx, "sys_ux_page_registry", registryData)
+	if err != nil {
+		return fmt.Errorf("failed to create page registry: %w", err)
+	}
+	registrySysID := getString(registry, "sys_id")
+
+	// ─── Step 4: Register in Workspaces menu ───────────────────────────
+	_, err = sdkClient.CreateRecord(ctx, "sys_ux_registry_m2m_category", map[string]interface{}{
+		"page_registry":       registrySysID,
+		"experience_category": workspaceCategorySysID,
+		"order":               100,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to register workspace in menu: %w", err)
+	}
+
+	// ─── Step 5: Create Home screen type ───────────────────────────────
+	screenType, err := sdkClient.CreateRecord(ctx, "sys_ux_screen_type", map[string]interface{}{
+		"name": flags.name + " Home",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create screen type: %w", err)
+	}
+	screenTypeSysID := getString(screenType, "sys_id")
+
+	// ─── Step 6: Create default Home screen ────────────────────────────
+	_, err = sdkClient.CreateRecord(ctx, "sys_ux_screen", map[string]interface{}{
+		"name":               "Default Home",
+		"app_config":         workspaceSysID,
+		"screen_type":        screenTypeSysID,
+		"parent_macroponent": appShellSysID,
+		"active":             true,
+		"order":              0,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create default screen: %w", err)
+	}
 
 	result := map[string]any{
-		"sys_id":      sysID,
-		"name":        getString(record, "name"),
-		"description": getString(record, "description"),
-		"active":      getString(record, "active"),
+		"sys_id":      workspaceSysID,
+		"name":        flags.name,
+		"description": flags.description,
+		"path":        path,
+		"url":         fmt.Sprintf("/now/%s/home", path),
 	}
 
 	return outputWriter.OK(result,
 		output.WithSummary(fmt.Sprintf("Created workspace '%s'", flags.name)),
 		output.WithBreadcrumbs(
-			output.Breadcrumb{Action: "show", Cmd: fmt.Sprintf("jsn records --table sys_ux_app_config %s", sysID), Description: "View workspace"},
-			output.Breadcrumb{Action: "add-page", Cmd: fmt.Sprintf("jsn workspace add-page --workspace %s --name home", sysID), Description: "Add a page"},
+			output.Breadcrumb{Action: "show", Cmd: fmt.Sprintf("jsn records --table sys_ux_app_config %s", workspaceSysID), Description: "View workspace config"},
+			output.Breadcrumb{Action: "show", Cmd: fmt.Sprintf("jsn records --table sys_ux_page_registry %s", registrySysID), Description: "View page registry"},
+			output.Breadcrumb{Action: "add-page", Cmd: fmt.Sprintf("jsn workspace add-page --workspace %s --name home", workspaceSysID), Description: "Add a page"},
+			output.Breadcrumb{Action: "add-screen", Cmd: fmt.Sprintf("jsn workspace add-screen --workspace %s --name list", workspaceSysID), Description: "Add a screen"},
 		),
 	)
 }
@@ -364,4 +446,36 @@ func resolveWorkspace(ctx context.Context, sdkClient *sdk.Client, identifier str
 		return "", fmt.Errorf("workspace not found: %s", identifier)
 	}
 	return getString(records[0], "sys_id"), nil
+}
+
+// lookupRecordSysID finds the first record in a table matching a query and returns its sys_id.
+func lookupRecordSysID(ctx context.Context, c *sdk.Client, table, query string) (string, error) {
+	records, err := c.ListRecords(ctx, table, &sdk.ListRecordsOptions{
+		Limit:  1,
+		Query:  query,
+		Fields: []string{"sys_id"},
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(records) == 0 {
+		return "", fmt.Errorf("no record found in %s matching: %s", table, query)
+	}
+	return getString(records[0], "sys_id"), nil
+}
+
+// slugify converts a name to a URL-friendly path segment.
+func slugify(name string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(name) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			prevDash = false
+		} else if !prevDash {
+			b.WriteRune('-')
+			prevDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }

--- a/internal/commands/workspace.go
+++ b/internal/commands/workspace.go
@@ -192,6 +192,60 @@ func runWorkspaceCreate(cmd *cobra.Command, flags workspaceCreateFlags) error {
 		return fmt.Errorf("failed to create home route: %w", err)
 	}
 
+	// ─── Step 8: Create page properties ────────────────────────────────
+	scopeSysID := getString(appConfig, "sys_scope")
+	if scopeSysID == "" {
+		// sys_scope may be a reference object
+		if ref, ok := appConfig["sys_scope"].(map[string]interface{}); ok {
+			scopeSysID = getString(ref, "value")
+		}
+	}
+	scopePrefix, err := getScopePrefix(ctx, sdkClient, scopeSysID)
+	if err != nil {
+		return fmt.Errorf("failed to get scope prefix: %w", err)
+	}
+
+	pageProps := []struct {
+		name  string
+		typ   string
+		value string
+	}{
+		{
+			name:  "chrome_header",
+			typ:   "json",
+			value: `{"privatePage":{"userPrefsEnabled":false,"searchEnabled":false,"currentScreenLinkConfiguration":{},"globalTools":{"collapsingMenuId":0,"primaryItems":[],"secondaryItems":[]},"notificationsEnabled":false},"publicPage":{"searchEnabled":false,"logoRoute":{},"actionButtons":[]}}`,
+		},
+		{
+			name:  "chrome_footer",
+			typ:   "json",
+			value: `{"public_page":{"enable_footer_topbar":false,"footer_topbar_options":{},"enable_footer_bar":false,"footer_bar_options":{}}}`,
+		},
+		{
+			name:  "chrome_toolbar",
+			typ:   "json",
+			value: `[{"id":"home","label":{"translatable":true,"message":"Home"},"icon":"home-fill","routeInfo":{"route":"home"},"group":"top","order":100,"badge":{},"presence":{},"availability":{},"viewportInfo":{}}]`,
+		},
+		{
+			name:  "chrome_tab",
+			typ:   "json",
+			value: `{"contextual":["record"],"newTabMenu":[],"maxMainTabLimit":10,"maxTotalSubTabLimit":30}`,
+		},
+	}
+
+	for _, prop := range pageProps {
+		_, err = sdkClient.CreateRecord(ctx, "sys_ux_page_property", map[string]interface{}{
+			"name":        prop.name,
+			"suffix":      prop.name,
+			"page":        registrySysID,
+			"type":        prop.typ,
+			"value":       prop.value,
+			"unique_name": fmt.Sprintf("%s.%s.root.global.%s", scopePrefix, registrySysID, prop.name),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create page property %s: %w", prop.name, err)
+		}
+	}
+
 	result := map[string]any{
 		"sys_id":      workspaceSysID,
 		"name":        flags.name,
@@ -476,6 +530,22 @@ func lookupRecordSysID(ctx context.Context, c *sdk.Client, table, query string) 
 		return "", fmt.Errorf("no record found in %s matching: %s", table, query)
 	}
 	return getString(records[0], "sys_id"), nil
+}
+
+// getScopePrefix returns the application scope prefix for a given scope sys_id.
+func getScopePrefix(ctx context.Context, c *sdk.Client, scopeSysID string) (string, error) {
+	records, err := c.ListRecords(ctx, "sys_scope", &sdk.ListRecordsOptions{
+		Limit:  1,
+		Query:  fmt.Sprintf("sys_id=%s", scopeSysID),
+		Fields: []string{"scope"},
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(records) == 0 {
+		return "", fmt.Errorf("no scope found")
+	}
+	return getString(records[0], "scope"), nil
 }
 
 // slugify converts a name to a URL-friendly path segment.


### PR DESCRIPTION
Closes #34

## Changes

- `workspace create` now bootstraps a fully functional, navigable workspace:
  - `sys_ux_app_config` — workspace configuration
  - `sys_ux_page_registry` — URL route with slugified path, app shell, and parent app
  - `sys_ux_registry_m2m_category` — registers workspace in the Workspaces menu
  - `sys_ux_screen_type` — Home screen collection
  - `sys_ux_screen` — Default Home screen
  - `sys_ux_app_route` — maps `/home` to the Home screen
  - `sys_ux_page_property` (×4) — chrome_header, chrome_footer, chrome_toolbar, chrome_tab
  - Custom `sys_ux_macroponent` extending Page Template with a Heading component
- Default references are looked up by name (no hardcoded sys_ids):
  - Workspace App Shell
  - Unified Navigation app shell
  - Workspace experience category
  - Page Template
  - Heading component
- Returns the workspace URL (`/now/<path>/home`) in output

## Usage

```bash
jsn workspace create --name "My Agent Workspace"
# → Created workspace 'My Agent Workspace'
# → URL: /now/my-agent-workspace/home
```

After creation, the workspace appears in the **Workspaces** menu in the Unified Navigator and renders a welcome heading on the home page.