### PR TITLE
fix(auth): human-readable PKCE mismatch error with self-serve resolut…

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -279,6 +279,17 @@ func (m *Manager) exchangeCode(instanceURL, clientID, code string, pkce *PKCEPar
 		return nil, fmt.Errorf("reading token response: %w", err)
 	}
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf(
+			"token exchange failed: PKCE challenge mismatch.\n\n"+
+				"ServiceNow cached a previous authorization grant — the auth code no\n"+
+				"longer matches the current PKCE challenge. To fix this:\n\n"+
+				"  1. Log out of your ServiceNow browser session (or use incognito)\n"+
+				"  2. Run:  jsn auth logout %s && jsn auth login %s\n\n"+
+				"Still stuck? You can bypass the interactive flow by obtaining a token\n"+
+				"directly and setting the SERVICENOW_OAUTH_TOKEN environment variable.",
+			instanceURL, instanceURL)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("token exchange failed (status %d): %s", resp.StatusCode, string(body))
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,7 +24,7 @@ type GitHubRelease struct {
 var (
 	// Version is the semantic version (e.g., "1.0.0")
 	// This is the default; overridden by ldflags at build/release time.
-	Version = "1.0.5"
+	Version = "1.0.6"
 
 	// Commit is the git commit SHA
 	Commit = "none"


### PR DESCRIPTION
…ion (fixes #61)

- Detect 401 from token exchange and explain PKCE challenge mismatch
- Guide users to logout+login or incognito to clear ServiceNow grant cache
- Point power users at SERVICENOW_OAUTH_TOKEN bypass
- Bump version 1.0.5 → 1.0.6