### PR TITLE
feat(auth): add --code and --print-url flags for bot-friendly OAuth flow

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -12,10 +12,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/jacebenson/jsn/internal/config"
 	"github.com/jacebenson/jsn/internal/sdk"
 	"golang.org/x/term"
 )
@@ -245,9 +247,85 @@ func buildAuthURL(instanceURL, clientID string, pkce *PKCEParams) string {
 	q.Set("code_challenge", pkce.CodeChallenge)
 	q.Set("code_challenge_method", "S256")
 	q.Set("scope", "openid")
+	q.Set("approval_prompt", "force")
 	u.RawQuery = q.Encode()
 
 	return u.String()
+}
+
+// BuildAuthURL generates PKCE params and builds the OAuth authorization URL.
+// PKCE state is persisted so LoginWithCode can complete the flow later.
+// The caller should use LoginWithCode on the same instance URL to finish.
+func (m *Manager) BuildAuthURL(instanceURL string) (string, error) {
+	instanceURL = normalizeURL(instanceURL)
+	clientID := getOAuthClientID()
+
+	pkce, err := generatePKCE()
+	if err != nil {
+		return "", fmt.Errorf("generating PKCE params: %w", err)
+	}
+
+	// Persist PKCE state for the subsequent code exchange
+	if err := savePKCEState(instanceURL, pkce); err != nil {
+		return "", fmt.Errorf("persisting PKCE state: %w", err)
+	}
+
+	return buildAuthURL(instanceURL, clientID, pkce), nil
+}
+
+// LoginWithCode completes the OAuth login flow using an authorization code
+// obtained from a prior BuildAuthURL call. The PKCE state must match.
+func (m *Manager) LoginWithCode(instanceURL, code string) error {
+	instanceURL = normalizeURL(instanceURL)
+	clientID := getOAuthClientID()
+
+	// Load saved PKCE state from BuildAuthURL
+	pkce, err := loadPKCEState(instanceURL)
+	if err != nil {
+		return fmt.Errorf("no pending login session for %s; run without --code first to generate one: %w", instanceURL, err)
+	}
+	defer os.Remove(pkceStatePath(instanceURL))
+
+	creds, err := m.exchangeCode(instanceURL, clientID, code, pkce)
+	if err != nil {
+		return err
+	}
+
+	return m.store.Save(instanceURL, creds)
+}
+
+// pkceStatePath returns the path to the saved PKCE state file for an instance.
+func pkceStatePath(instance string) string {
+	filename := strings.ReplaceAll(instance, "://", "_")
+	filename = strings.ReplaceAll(filename, "/", "_")
+	filename = strings.ReplaceAll(filename, ":", "_")
+	return filepath.Join(config.GlobalConfigDir(), "pkce", filename+".json")
+}
+
+// savePKCEState persists PKCE params so the code exchange can use the same verifier.
+func savePKCEState(instance string, pkce *PKCEParams) error {
+	path := pkceStatePath(instance)
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(pkce, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// loadPKCEState loads previously saved PKCE params for the code exchange.
+func loadPKCEState(instance string) (*PKCEParams, error) {
+	data, err := os.ReadFile(pkceStatePath(instance))
+	if err != nil {
+		return nil, err
+	}
+	var pkce PKCEParams
+	if err := json.Unmarshal(data, &pkce); err != nil {
+		return nil, err
+	}
+	return &pkce, nil
 }
 
 // exchangeCode exchanges the authorization code for access/refresh tokens

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -52,7 +52,10 @@ INSTANCE URL FORMATS:
 }
 
 func newAuthLoginCmd() *cobra.Command {
-	return &cobra.Command{
+	var code string
+	printURL := false
+
+	cmd := &cobra.Command{
 		Use:   "login [instance-url|profile-name]",
 		Short: "Login to a ServiceNow instance via OAuth",
 		Long: `Authenticate with a ServiceNow instance using OAuth 2.0 + PKCE.
@@ -62,6 +65,10 @@ This uses ServiceNow's SDK-style OAuth flow:
 2. You complete authentication in browser
 3. ServiceNow shows authorization code on page
 4. Copy and paste that code back to CLI
+
+For non-interactive/bot use:
+  --print-url  Print the OAuth URL and exit (PKCE state is saved for --code)
+  --code       Provide the authorization code directly, skipping the interactive prompt
 
 You can specify either a full URL or a profile name (e.g., "dev373698").
 
@@ -75,6 +82,12 @@ EXAMPLES:
 
   # Login with profile name
   jsn auth login dev373698
+
+  # Non-interactive: print URL for a bot to capture
+  jsn auth login https://dev12345.service-now.com --print-url
+
+  # Non-interactive: provide code obtained from browser flow
+  jsn auth login https://dev12345.service-now.com --code CODE
 
   # From environment variable (automation/CI)
   export SERVICENOW_OAUTH_TOKEN=your-token
@@ -122,9 +135,26 @@ Find your instance URL in your browser's address bar when logged into ServiceNow
 
 			instanceURL = config.NormalizeInstanceURL(instanceURL)
 
-			// Start OAuth flow
-			if err := app.Auth.Login(instanceURL); err != nil {
-				return err
+			// Non-interactive: --print-url just prints the URL and exits
+			if printURL {
+				authURL, err := app.Auth.BuildAuthURL(instanceURL)
+				if err != nil {
+					return err
+				}
+				fmt.Println(authURL)
+				return nil
+			}
+
+			// Non-interactive: --code exchanges the provided code directly
+			if code != "" {
+				if err := app.Auth.LoginWithCode(instanceURL, code); err != nil {
+					return err
+				}
+			} else {
+				// Interactive: full OAuth flow with browser + prompt
+				if err := app.Auth.Login(instanceURL); err != nil {
+					return err
+				}
 			}
 
 			// Create temporary auth provider for the new instance
@@ -184,6 +214,11 @@ Find your instance URL in your browser's address bar when logged into ServiceNow
 			return app.OK(result, output.WithSummary(summary))
 		},
 	}
+
+	cmd.Flags().StringVar(&code, "code", "", "Authorization code from browser (bypasses interactive prompt)")
+	cmd.Flags().BoolVar(&printURL, "print-url", false, "Print the OAuth URL and exit (saves PKCE state for --code)")
+
+	return cmd
 }
 
 // instanceAuthProvider is a custom auth provider for a specific instance.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,7 +24,7 @@ type GitHubRelease struct {
 var (
 	// Version is the semantic version (e.g., "1.0.0")
 	// This is the default; overridden by ldflags at build/release time.
-	Version = "1.0.5"
+	Version = "1.0.7"
 
 	// Commit is the git commit SHA
 	Commit = "none"


### PR DESCRIPTION
## Summary

Makes the OAuth PKCE login flow usable by bots/agents (like Hermes) by adding two new flags that bypass the interactive browser + hidden-prompt flow.

## Changes

###  flag
- Generates PKCE params, saves them to `~/.config/servicenow/pkce/<instance>.json`
- Prints only the OAuth URL to stdout and exits
- No browser opening, no interactive prompt

### `--code <code>` flag
- Loads saved PKCE state, exchanges the code directly
- No `term.ReadPassword`, no stdin piping required
- Cleans up PKCE state file after successful exchange

### `approval_prompt=force`
- Added to the OAuth URL query params
- Prevents ServiceNow from silently reusing a cached grant, which caused the PKCE challenge mismatch bug from #61

## Bot Flow

```bash
# Step 1: print URL (saves PKCE state)
URL=$(jsn auth login --quiet --print-url https://instance.service-now.com)

# Step 2: bot navigates browser, captures code from /sdk-oauth.do redirect

# Step 3: exchange code (loads PKCE state, cleans up after)
jsn auth login --code "$CODE" https://instance.service-now.com
```

## Testing
- [x] `--print-url` prints clean URL with `approval_prompt=force`
- [x] `--code` exchanges code and saves credentials successfully
- [x] PKCE state file cleaned up after `--code`
- [x] `approval_prompt=force` forces re-consent each time
- [x] All existing tests pass
- [x] `go vet` and `golangci-lint` pass

Closes #61