### PR TITLE
fix(incidents): guard against nil SDK panic when no instance configured

### DIFF
--- a/internal/commands/incidents.go
+++ b/internal/commands/incidents.go
@@ -302,6 +302,11 @@ func listIncidents(ctx context.Context, app *appctx.App, query string, columns [
 		columns = incidentDefaultColumns
 	}
 
+	// Check if SDK is initialized (requires a configured instance)
+	if app.SDK == nil {
+		return output.ErrUsage("No instance configured. Run 'jsn setup' or 'jsn auth login <instance-url>' first.")
+	}
+
 	// Check if we're in an interactive terminal
 	isInteractive := output.IsTTY(os.Stdout) && output.IsTTY(os.Stdin)
 


### PR DESCRIPTION
## Summary

When running `jsn incidents list --markdown` (or any incident command) on a machine where no ServiceNow instance is configured, `app.SDK` is nil because `NewApp` only creates the SDK client when `GetEffectiveInstance()` returns a non-empty string. The list function calls `app.SDK.List(...)` without a nil check, causing a nil pointer dereference panic.

## Fix

Added a nil check for `app.SDK` at the top of `listIncidents` before any SDK interaction. Returns a clear usage error instead of crashing:

```
Error: usage_error: No instance configured. Run 'jsn setup' or 'jsn auth login <instance-url>' first.
```

## Related

The same pattern (`app.SDK != nil` guard) is already used in `internal/commands/profiles.go:292`. This brings the incidents command in line with that convention.

Fixes the crash reported in the g_ck thread.