### PR TITLE
feat(auth): add --code and --print-url flags for bot-friendly OAuth flow

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -10,6 +10,37 @@ import { execSync } from 'node:child_process';
 import { globalConfigDir, normalizeInstanceURL } from './config.js';
 import { errAuth } from './errors.js';
 
+// ─── PKCE state persistence (shared with Go version) ───
+
+function pkceStatePath(instance) {
+  const dir = path.join(globalConfigDir(), 'pkce');
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const filename = instance.replace(/:\/\//g, '_').replace(/\//g, '_').replace(/:/g, '_') + '.json';
+  return path.join(dir, filename);
+}
+
+function savePKCEState(instance, pkce) {
+  const filePath = pkceStatePath(instance);
+  fs.writeFileSync(filePath, JSON.stringify(pkce, null, 2), { mode: 0o600 });
+}
+
+function loadPKCEState(instance) {
+  try {
+    const data = fs.readFileSync(pkceStatePath(instance), 'utf-8');
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+}
+
+function removePKCEState(instance) {
+  try {
+    fs.unlinkSync(pkceStatePath(instance));
+  } catch {
+    // ignore
+  }
+}
+
 const DEFAULT_OAUTH_CLIENT_ID = '543e5655f77746a28228c6009a599dfb';
 const REDIRECT_URI = '/sdk-oauth.do';
 
@@ -273,6 +304,43 @@ export class AuthManager {
     }
 
     console.log('\nExchanging authorization code for tokens...');
+    const newCreds = await this.exchangeCode(instanceURL, clientID, code, pkce);
+    saveCredentials(instanceURL, newCreds);
+    return newCreds;
+  }
+
+  /**
+   * Build an OAuth authorization URL and persist PKCE state for later use.
+   * After calling this, the user can visit the URL in a browser and then
+   * call loginWithCode() with the resulting authorization code.
+   */
+  buildAuthURL(instanceURL) {
+    instanceURL = normalizeInstanceURL(instanceURL);
+    const clientID = getOAuthClientID();
+    const pkce = generatePKCE();
+    savePKCEState(instanceURL, pkce);
+    return buildAuthURL(instanceURL, clientID, pkce);
+  }
+
+  /**
+   * Complete login using an authorization code obtained from a prior buildAuthURL() call.
+   * The PKCE state must have been saved by an earlier buildAuthURL() call.
+   */
+  async loginWithCode(instanceURL, code) {
+    instanceURL = normalizeInstanceURL(instanceURL);
+    const clientID = getOAuthClientID();
+    const pkce = loadPKCEState(instanceURL);
+    if (!pkce) {
+      throw errAuth(
+        `No pending login session for ${instanceURL}.\n\n` +
+        'Run without --code first to generate one:\n' +
+        `  jsn auth login ${instanceURL} --print-url\n\n` +
+        'This generates the PKCE challenge and saves it. Then call:\n' +
+        `  jsn auth login ${instanceURL} --code CODE`
+      );
+    }
+    removePKCEState(instanceURL);
+
     const newCreds = await this.exchangeCode(instanceURL, clientID, code, pkce);
     saveCredentials(instanceURL, newCreds);
     return newCreds;

--- a/src/commands/auth.js
+++ b/src/commands/auth.js
@@ -1,61 +1,211 @@
 import { getEffectiveInstance, normalizeInstanceURL } from '../config.js';
+import { errUsage } from '../errors.js';
+import process from 'node:process';
 
 export function authCmd(wrap) {
   return {
     command: 'auth <subcommand>',
-    describe: 'Manage authentication',
+    describe: 'Manage OAuth authentication',
     builder: (yargs) => {
       return yargs
         .command({
           command: 'login [instance]',
-          describe: 'Authenticate with a ServiceNow instance',
+          describe: 'Authenticate with a ServiceNow instance via OAuth',
+          builder: (sub) => sub
+            .option('code', {
+              describe: 'Authorization code from browser (bypasses interactive prompt)',
+              type: 'string',
+            })
+            .option('print-url', {
+              describe: 'Print the OAuth URL and exit (saves PKCE state for --code)',
+              type: 'boolean',
+            }),
           handler: wrap(async (argv, app) => {
-            const instance = argv.instance ? normalizeInstanceURL(argv.instance) : getEffectiveInstance(app.config);
-            if (!instance) {
-              throw new Error('No instance configured. Set via --instance or run: jsn setup');
+            let instanceURL;
+            if (argv.instance) {
+              // Check if it's a profile name first
+              const profiles = app.config.profiles || {};
+              if (profiles[argv.instance] && profiles[argv.instance].instance_url) {
+                instanceURL = normalizeInstanceURL(profiles[argv.instance].instance_url);
+              } else {
+                instanceURL = normalizeInstanceURL(argv.instance);
+              }
+            } else {
+              instanceURL = getEffectiveInstance(app.config);
+              if (!instanceURL) {
+                // Try interactive profile picker
+                const profileNames = Object.keys(app.config.profiles || {});
+                if (profileNames.length > 0 && app.isInteractive()) {
+                  const { search } = await import('@inquirer/prompts');
+                  const choices = profileNames.map(name => ({
+                    name: `${name} — ${app.config.profiles[name].instance_url}`,
+                    value: name,
+                  }));
+                  const selected = await search({
+                    message: 'Select a profile:',
+                    source: (input) => {
+                      const filter = (input || '').toLowerCase();
+                      return choices.filter(c => c.name.toLowerCase().includes(filter));
+                    },
+                  });
+                  instanceURL = normalizeInstanceURL(app.config.profiles[selected].instance_url);
+                } else {
+                  throw errUsage(`Instance URL required.
+
+Examples:
+  jsn auth login https://dev12345.service-now.com
+  jsn auth login dev373698
+  jsn auth login https://acme.service-now.com
+
+Find your instance URL in your browser's address bar when logged into ServiceNow.`);
+                }
+              }
             }
-            await app.auth.login(instance);
-            app.ok({ authenticated: true, instance }, { summary: `Authenticated with ${instance}` });
+
+            // --print-url: just print the URL and exit
+            if (argv.printUrl) {
+              const authURL = app.auth.buildAuthURL(instanceURL);
+              console.log(authURL);
+              return;
+            }
+
+            // --code: exchange the provided authorization code directly
+            if (argv.code) {
+              await app.auth.loginWithCode(instanceURL, argv.code);
+            } else {
+              // Interactive: full OAuth flow with browser + prompt
+              await app.auth.login(instanceURL);
+            }
+
+            // Verify auth by fetching current user
+            let username = '';
+            try {
+              if (!app.sdk) {
+                const { SDKClient } = await import('../sdk.js');
+                app.sdk = new SDKClient(instanceURL, app.auth);
+              }
+              const user = await app.sdk.getCurrentUser();
+              username = user?.user_name || user?.name || '';
+            } catch {
+              // Non-fatal — token is saved, just couldn't verify
+            }
+
+            // Save to profiles
+            const profileName = instanceURL.replace(/https?:\/\//, '').replace(/\.service-now\.com.*/, '').replace(/[^a-zA-Z0-9]/g, '-');
+            if (!app.config.profiles) {
+              app.config.profiles = {};
+            }
+            app.config.profiles[profileName] = {
+              instance_url: instanceURL,
+              auth_method: 'oauth',
+              username: username || undefined,
+            };
+
+            // Set as default if this is the first one
+            const setDefault = !app.config.instanceURL && !app.config.defaultProfile;
+            if (setDefault) {
+              app.config.instanceURL = instanceURL;
+              app.config.defaultProfile = profileName;
+            }
+
+            const { saveConfig } = await import('../config.js');
+            saveConfig(app.config);
+
+            const result = {
+              authenticated: true,
+              instance: instanceURL,
+              username: username || undefined,
+              default: setDefault || undefined,
+            };
+            const summary = username
+              ? `✓ Authenticated to ${instanceURL} as ${username}`
+              : `✓ Authenticated to ${instanceURL}`;
+            app.ok(result, { summary });
           }),
         })
         .command({
-          command: 'logout',
-          describe: 'Remove stored credentials',
-          handler: wrap(async (_argv, app) => {
-            const instance = getEffectiveInstance(app.config);
-            if (!instance) {
-              throw new Error('No instance configured');
+          command: 'logout [instance]',
+          describe: 'Remove stored OAuth credentials',
+          handler: wrap(async (argv, app) => {
+            let instanceURL;
+            if (argv.instance) {
+              instanceURL = normalizeInstanceURL(argv.instance);
+            } else {
+              instanceURL = getEffectiveInstance(app.config);
+              if (!instanceURL) {
+                throw errUsage(`No instance specified.
+
+Examples:
+  jsn auth logout
+  jsn auth logout https://dev12345.service-now.com`);
+              }
             }
-            app.auth.logout(instance);
-            app.ok({ logged_out: true, instance }, { summary: `Logged out from ${instance}` });
+            app.auth.logout(instanceURL);
+            app.ok({ logged_out: true, instance: instanceURL }, { summary: `✓ Logged out from ${instanceURL}` });
           }),
         })
         .command({
           command: 'status',
-          describe: 'Show authentication status',
+          describe: 'Show detailed authentication status',
           handler: wrap(async (_argv, app) => {
-            const instance = getEffectiveInstance(app.config);
-            if (!instance) {
-              app.ok({ authenticated: false, instance: null }, { summary: 'No instance configured' });
-              return;
+            const defaultInstance = getEffectiveInstance(app.config);
+
+            // Check environment auth
+            const envToken = process.env.SERVICENOW_OAUTH_TOKEN || '';
+
+            const profiles = [];
+            for (const [name, profile] of Object.entries(app.config.profiles || {})) {
+              const isAuth = app.auth.isAuthenticatedFor(profile.instance_url);
+              profiles.push({
+                name,
+                instance: profile.instance_url,
+                authenticated: isAuth,
+                default: profile.instance_url === defaultInstance,
+              });
             }
-            const isAuth = app.auth.isAuthenticatedFor(instance);
-            app.ok({ authenticated: isAuth, instance }, { summary: isAuth ? `Authenticated with ${instance}` : `Not authenticated with ${instance}` });
+
+            app.ok({
+              default_instance: defaultInstance,
+              authenticated: app.auth.isAuthenticated(),
+              environment_auth: envToken ? true : undefined,
+              profiles,
+            }, { summary: `${profiles.length} profile(s)` });
           }),
         })
         .command({
-          command: 'refresh',
-          describe: 'Refresh OAuth token',
-          handler: wrap(async (_argv, app) => {
-            const instance = getEffectiveInstance(app.config);
-            if (!instance) {
-              throw new Error('No instance configured');
-            }
-            await app.auth.refreshToken(instance, await app.auth.getCredentialsFor(instance));
-            app.ok({ refreshed: true, instance }, { summary: `Token refreshed for ${instance}` });
-          }),
-        })
+          command: 'refresh [instance]',
+          describe: 'Refresh OAuth token for an instance',
+          handler: wrap(async (argv, app) => {
+            let instanceURL;
+            if (argv.instance) {
+              // Check if it's a profile name or URL
+              const profiles = app.config.profiles || {};
+              if (profiles[argv.instance] && profiles[argv.instance].instance_url) {
+                instanceURL = normalizeInstanceURL(profiles[argv.instance].instance_url);
+              } else {
+                instanceURL = normalizeInstanceURL(argv.instance);
+              }
+            } else {
+              instanceURL = getEffectiveInstance(app.config);
+              if (!instanceURL) {
+                throw errUsage(`No instance specified and no default configured.
 
+Examples:
+  jsn auth refresh
+  jsn auth refresh https://dev12345.service-now.com
+  jsn auth refresh dev12345`);
+              }
+            }
+
+            const creds = await app.auth.getCredentialsFor(instanceURL);
+            const refreshed = await app.auth.refreshToken(instanceURL, creds);
+            app.ok({
+              refreshed: true,
+              instance: instanceURL,
+              expires_at: refreshed.expires_at,
+            }, { summary: `✓ Token refreshed for ${instanceURL}` });
+          }),
+        });
     },
     handler: () => {},
   };

--- a/src/commands/dev/_generic.js
+++ b/src/commands/dev/_generic.js
@@ -321,7 +321,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
     aliases: aliases || [],
     describe: `Manage ${name} (e.g. "${name} list --query nameLIKEincident")`,
     builder,
-    handler: (argv) => {
+    handler: (_argv) => {
       // This handler only runs when no subcommand is matched (the default case).
       // Show help for the subcommands available.
       console.log(`Manage ${name} from the ${table} table.`);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -139,6 +139,6 @@ export function parseDataArg(argv) {
   try {
     return JSON.parse(raw);
   } catch (e) {
-    throw new Error(`Invalid JSON: ${e.message}\n\nHint: On Windows PowerShell, use --data-file instead of --data to avoid quote mangling.\nRaw value: ${raw.substring(0, 200)}`);
+    throw new Error(`Invalid JSON: ${e.message}\n\nHint: On Windows PowerShell, use --data-file instead of --data to avoid quote mangling.\nRaw value: ${raw.substring(0, 200)}`, { cause: e });
   }
 }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -165,6 +165,22 @@ export class SDKClient {
     await this.request(endpoint, { method: 'DELETE' });
   }
 
+  async getCurrentUser() {
+    const params = new URLSearchParams();
+    params.set('sysparm_query', 'user_name=javascript:gs.getUserName()');
+    params.set('sysparm_limit', '1');
+    params.set('sysparm_display_value', 'all');
+    params.set('sysparm_fields', 'sys_id,user_name,name');
+    const records = await this.list('sys_user', params);
+    if (records.length === 0) return null;
+    const r = records[0];
+    return {
+      sys_id: r.sys_id?.value || r.sys_id,
+      user_name: r.user_name?.display_value || r.user_name,
+      name: r.name?.display_value || r.name,
+    };
+  }
+
   async inspectFlow(identifier) {
     const isSysID = identifier.length === 32 && /^[0-9a-fA-F]+$/.test(identifier);
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -3,7 +3,6 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execSync } from 'node:child_process';
 import { normalizeInstanceURL } from '../src/config.js';
 
 // ─── Config tests ───

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -92,7 +92,7 @@ describe('SDK Architecture', () => {
     const { SDKClient } = await import('../src/sdk.js');
 
     // Core CRUD methods — must be present
-    const coreMethods = ['list', 'get', 'create', 'update', 'delete', 'request', 'rawRequest', 'aggregateCount', 'executeScript'];
+    const coreMethods = ['list', 'get', 'create', 'update', 'delete', 'request', 'rawRequest', 'aggregateCount', 'executeScript', 'getCurrentUser'];
     for (const method of coreMethods) {
       assert.strictEqual(typeof SDKClient.prototype[method], 'function', `SDKClient must have method: ${method}`);
     }


### PR DESCRIPTION
## Summary

Port the OAuth PKCE state persistence and non-interactive auth flow from the Go implementation to the Node.js CLI, enabling bot/agent-driven authentication without interactive prompts.

## Changes

### PKCE State Persistence
- Added `savePKCEState()`, `loadPKCEState()`, `removePKCEState()` functions in `src/auth.js`
- Shared storage directory with Go version: `~/.config/servicenow/pkce/`
- Enables two-step OAuth flow: generate URL → save PKCE → exchange code

### New AuthManager Methods
- `buildAuthURL(instanceURL)` — generates OAuth URL and persists PKCE state for later `--code` use
- `loginWithCode(instanceURL, code)` — loads saved PKCE state and exchanges authorization code

### New CLI Flags
- `--code` — provide authorization code directly, skipping the interactive prompt
- `--print-url` — print the OAuth URL and exit (saves PKCE state for subsequent `--code`)

### Improved UX
- Profile name resolution — `jsn auth login dev12345` now works with profile names
- Interactive profile picker when no instance is specified
- `logout` and `refresh` accept optional instance argument
- Post-login verification: fetches current user and saves username to profile
- Better help text matching Go version

### SDK
- Added `getCurrentUser()` to `SDKClient` (mirrors Go's `internal/sdk/context.go`)

## Testing
- All 12 existing tests pass
- Verified CLI help output shows new flags
- Syntax check passes on all modified files