### PR TITLE
feat: add grouped help with categorized commands

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,7 @@ import { hideBin } from 'yargs/helpers';
 import process from 'node:process';
 import { loadConfig, getEffectiveInstance } from './config.js';
 import { App } from './app.js';
+import { renderHelp } from './help.js';
 
 // Command modules
 import { setupCmd } from './commands/setup.js';
@@ -139,6 +140,13 @@ export const cli = yargs(hideBin(process.argv))
   .version(false)
   .strictCommands()
   .strictOptions(false)
-  .epilogue('TIPS\n'
-    + '  --query is available on every list command (e.g. "incidents list --query priority=1")\n'
-    + '  Use "jsn <command> --help" for details, or "jsn <command> list --help" for list options');
+  .fail((msg, err) => {
+    if (err) throw err;
+    // No command given → show custom grouped help instead of yargs error
+    if (msg === 'You must specify a command') {
+      process.stdout.write(renderHelp());
+      process.exit(0);
+    }
+    process.stderr.write(`Error: ${msg}\n`);
+    process.exit(1);
+  });

--- a/src/help.js
+++ b/src/help.js
@@ -1,0 +1,84 @@
+// Custom grouped help renderer
+// Mirrors the Go version's custom Cobra help template
+
+const COMMAND_GROUPS = {
+  'CORE COMMANDS': [
+    { name: 'incidents', alias: 'inc', desc: 'Manage incidents' },
+    { name: 'changes', alias: 'chg', desc: 'Manage change requests' },
+    { name: 'requests', alias: 'req', desc: 'Manage service catalog requests' },
+    { name: 'tasks', alias: 'task', desc: 'Manage catalog tasks' },
+    { name: 'tickets', alias: 'ticket', desc: 'Query generic tickets' },
+  ],
+  'DATA & ADMIN': [
+    { name: 'records', desc: 'Generic Table API for any table' },
+    { name: 'users', alias: 'user', desc: 'Manage ServiceNow users' },
+    { name: 'groups', alias: 'group', desc: 'Manage groups' },
+    { name: 'groupmembers', alias: 'gm', desc: 'Manage group memberships' },
+    { name: 'grouproles', alias: 'gr', desc: 'Manage group roles' },
+  ],
+  'DEVELOPMENT': [
+    { name: 'dev', desc: 'Manage development artifacts (flows, includes, rules, ACLs, etc.)' },
+  ],
+  'CONFIGURATION': [
+    { name: 'setup', desc: 'Interactive first-time setup' },
+    { name: 'auth', desc: 'Manage OAuth authentication' },
+    { name: 'profiles', alias: 'profile', desc: 'Manage instance profiles' },
+  ],
+};
+
+const UTILITY_COMMANDS = [
+  { name: 'version', desc: 'Show version information' },
+];
+
+function renderGroup(name, commands) {
+  const lines = [`\n${name}`];
+  lines.push('─'.repeat(50));
+  for (const cmd of commands) {
+    const aliasPart = cmd.alias ? ` (${cmd.alias})` : '';
+    const padded = `  jsn ${cmd.name}`.padEnd(22);
+    lines.push(`${padded}${cmd.desc}${aliasPart}`);
+  }
+  return lines.join('\n');
+}
+
+function renderFlags() {
+  return `
+FLAGS
+  --instance    ServiceNow instance URL (e.g., https://dev12345.service-now.com)  [string]
+  -p, --profile Configuration profile to use                                      [string]
+  --format      Output format: auto, json, markdown, styled, quiet                [string]
+  --json        Output in JSON format                                            [boolean]
+  -q, --quiet   Output only data, no envelope                                    [boolean]
+  --styled      Force styled output                                              [boolean]
+  --markdown    Output in Markdown format                                        [boolean]
+  --help        Show help                                                        [boolean]`;
+}
+
+function renderTips() {
+  return `
+TIPS
+  --query is available on every list command (e.g. "incidents list --query priority=1")
+  Use "jsn <command> --help" for details, or "jsn <command> list --help" for list options
+
+LEARN MORE
+  Use "jsn <command> --help" for more information about a command.`;
+}
+
+export function renderHelp() {
+  const sections = Object.entries(COMMAND_GROUPS).map(([name, cmds]) => renderGroup(name, cmds));
+  const utilitySection = renderGroup('UTILITY', UTILITY_COMMANDS);
+
+  return [
+    'Usage: jsn <command> [options]',
+    '',
+    `Command-line interface for ServiceNow`,
+    '',
+    ...sections,
+    '',
+    utilitySection,
+    '',
+    renderFlags(),
+    renderTips(),
+    '',
+  ].join('\n');
+}


### PR DESCRIPTION
## Help System Categorization

Replaces the flat yargs command list with a grouped layout matching the Go version's custom Cobra template.

### Before
```
Commands:
  jsn setup        Interactive first-time setup
  jsn auth         Manage OAuth authentication
  jsn profiles     Manage configuration profiles
  jsn records      Query and manage records...
  jsn incidents    Manage incidents
  ...
```

### After
```
CORE COMMANDS
  jsn incidents    Manage incidents (inc)
  jsn changes      Manage change requests (chg)
  ...

DATA & ADMIN
  jsn records      Generic Table API for any table
  jsn users        Manage ServiceNow users (user)
  ...

DEVELOPMENT
  jsn dev          Manage development artifacts

CONFIGURATION
  jsn setup        Interactive first-time setup
  jsn auth         Manage OAuth authentication
  jsn profiles     Manage instance profiles (profile)

UTILITY
  jsn version      Show version information
```

### How it works
- `src/help.js` — New module with `renderHelp()` that builds the categorized output
- `src/cli.js` — Updated `.fail()` handler to intercept `demandCommand` errors (no command given) and show custom help instead
- Yargs' `.help()` is preserved for subcommand-level `--help` (e.g. `jsn incidents --help`)

### Verification
- `jsn` (no args) → custom grouped help
- `jsn incidents --help` → yargs subcommand help (preserved)
- `npm run lint` — clean
- `npm test` — 37/37 passing