### PR TITLE
chore: bump to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump for the `--sys-id` fix on `records list` (PR #78 / issue #77).