### PR TITLE
fix: add --fields alias and fix scope comparison in dev update/delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {

--- a/src/commands/_ticket.js
+++ b/src/commands/_ticket.js
@@ -18,7 +18,7 @@ export function buildTicketCommands(table, displayName, alias, defaultColumns, s
           describe: `List ${table}`,
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' })
             .option('offset', { alias: 'o', type: 'number', default: 0, describe: 'Offset for pagination' }),
           handler: wrap(async (argv, app) => {

--- a/src/commands/dev/_generic.js
+++ b/src/commands/dev/_generic.js
@@ -81,7 +81,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
         describe: `List ${name}`,
         builder: (y) => y
           .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true^priority=1")' })
-          .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "name,label,super_class")' })
+          .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "name,label,super_class")' })
           .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' }),
         handler: wrap(async (argv, app) => {
           const query = argv.query || '';
@@ -251,6 +251,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
             const findParams = new URLSearchParams();
             findParams.set('sysparm_query', `${queryField}=${id}`);
             findParams.set('sysparm_limit', '1');
+            findParams.set('sysparm_display_value', 'all');
             const records = await app.sdk.list(table, findParams);
             if (records.length === 0) {
               throw new Error(`${singular} not found: ${id}`);
@@ -280,6 +281,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
             const findParams = new URLSearchParams();
             findParams.set('sysparm_query', `${queryField}=${id}`);
             findParams.set('sysparm_limit', '1');
+            findParams.set('sysparm_display_value', 'all');
             const records = await app.sdk.list(table, findParams);
             if (records.length === 0) {
               throw new Error(`${singular} not found: ${id}`);

--- a/src/commands/dev/flows.js
+++ b/src/commands/dev/flows.js
@@ -13,7 +13,7 @@ export function flowsCmd(wrap) {
           describe: 'List flows',
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' }),
           handler: wrap(async (argv, app) => {
             const columns = argv.columns ? argv.columns.split(',') : ['name', 'active', 'description', 'sys_created_by', 'sys_updated_on'];

--- a/src/commands/dev/logs.js
+++ b/src/commands/dev/logs.js
@@ -13,7 +13,7 @@ export function logsCmd(wrap) {
           describe: 'List system logs',
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { alias: 'l', type: 'number', default: 50, describe: 'Max records' }),
           handler: wrap(async (argv, app) => {
             const columns = argv.columns ? argv.columns.split(',') : ['level', 'message', 'source', 'created'];

--- a/src/commands/dev/scopes.js
+++ b/src/commands/dev/scopes.js
@@ -13,7 +13,7 @@ export function scopesCmd(wrap) {
           describe: 'List application scopes',
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' }),
           handler: wrap(async (argv, app) => {
             const columns = argv.columns ? argv.columns.split(',') : ['name', 'scope', 'short_description', 'active'];

--- a/src/commands/dev/updatesets.js
+++ b/src/commands/dev/updatesets.js
@@ -13,7 +13,7 @@ export function updateSetsCmd(wrap) {
           describe: 'List update sets',
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' }),
           handler: wrap(async (argv, app) => {
             const columns = argv.columns ? argv.columns.split(',') : ['name', 'state', 'application'];

--- a/src/commands/groupmembers.js
+++ b/src/commands/groupmembers.js
@@ -13,7 +13,7 @@ export function groupMembersCmd(wrap) {
           describe: 'List group members',
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' }),
           handler: wrap(async (argv, app) => {
             const columns = argv.columns ? argv.columns.split(',') : ['user.name', 'group.name'];

--- a/src/commands/grouproles.js
+++ b/src/commands/grouproles.js
@@ -13,7 +13,7 @@ export function groupRolesCmd(wrap) {
           describe: 'List group roles',
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' }),
           handler: wrap(async (argv, app) => {
             const columns = argv.columns ? argv.columns.split(',') : ['group.name', 'role.name'];

--- a/src/commands/groups.js
+++ b/src/commands/groups.js
@@ -13,7 +13,7 @@ export function groupsCmd(wrap) {
           describe: 'List groups',
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' }),
           handler: wrap(async (argv, app) => {
             const columns = argv.columns ? argv.columns.split(',') : ['name', 'manager', 'email'];

--- a/src/commands/records.js
+++ b/src/commands/records.js
@@ -32,7 +32,7 @@ export function recordsCmd(wrap) {
             .option('table', { type: 'string', demandOption: true, describe: 'Table name' })
             .option('sys-id', { type: 'string', describe: 'Record sys_id (filters to a single record)' })
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { type: 'number', default: 20, describe: 'Max records' })
             .option('offset', { type: 'number', default: 0, describe: 'Offset' }),
           handler: wrap(async (argv, app) => {
@@ -112,7 +112,7 @@ export function recordsCmd(wrap) {
           builder: (y) => y
             .option('table', { type: 'string', demandOption: true, describe: 'Table name' })
             .option('sys-id', { type: 'string', demandOption: true, describe: 'Record sys_id' })
-            .option('columns', { type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' }),
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' }),
           handler: wrap(async (argv, app) => {
             const params = new URLSearchParams();
             params.set('sysparm_query', `sys_id=${argv['sys-id']}`);

--- a/src/commands/tickets.js
+++ b/src/commands/tickets.js
@@ -13,7 +13,7 @@ export function ticketsCmd(wrap) {
           describe: 'List tickets',
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "active=true^priority=1")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description,priority")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description,priority")' })
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' })
             .option('offset', { alias: 'o', type: 'number', default: 0, describe: 'Offset' }),
           handler: wrap(async (argv, app) => {

--- a/src/commands/users.js
+++ b/src/commands/users.js
@@ -13,7 +13,7 @@ export function usersCmd(wrap) {
           describe: 'List users',
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
-            .option('columns', { alias: 'c', type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
+            .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' }),
           handler: wrap(async (argv, app) => {
             const columns = argv.columns ? argv.columns.split(',') : ['user_name', 'name', 'email', 'active'];


### PR DESCRIPTION
## Changes

Two fixes rolled into one PR since they both touch the dev command handlers:

### 1. `--fields` alias for `--columns`

ServiceNow's REST API uses `sysparm_fields`, so users naturally reach for `--fields`. Added `fields` as an alias alongside `c` for every `--columns` option — 13 locations across 10 files.

### 2. Scope comparison bug in `dev <resource> update` and `dev <resource> delete`

The update and delete handlers in `dev/_generic.js` fetched records without `sysparm_display_value=all`, so `sys_scope` (a reference field) came back as a raw sys_id instead of the display value (scope name). The subsequent comparison in `checkScope()` compared sys_id vs scope name — they never matched, causing a false "record is in scope 'X', but your current scope is 'Y'" error on every scoped record.

Fixed by adding `sysparm_display_value=all` to the find params in both handlers, so `getStringField` resolves `sys_scope` to its display value.

## Affected commands

- `jsn records list` / `jsn records get` — `--fields` alias added
- `jsn dev <resource> list` (all dev resources) — `--fields` alias added
- `jsn dev <resource> update` — scope bug fixed + `--fields` alias on list
- `jsn dev <resource> delete` — scope bug fixed
- `jsn incidents`, `jsn changes`, `jsn groups`, `jsn users`, `jsn tickets` — `--fields` alias added
