### PR TITLE
bump: 0.2.0 → 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jacebenson/jsn",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "0.2.0",
+  "version": "2.0.1",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,7 @@ import { groupRolesCmd } from './commands/grouproles.js';
 import { ticketsCmd } from './commands/tickets.js';
 import { versionCmd } from './commands/version.js';
 import { devCmd } from './commands/dev.js';
-import { skillCmd } from './commands/skill.js';
+import { skillCmd, checkSkill } from './commands/skill.js';
 
 function wrap(handler) {
   return async (argv) => {
@@ -87,6 +87,11 @@ export const cli = yargs(hideBin(process.argv))
     type: 'boolean',
     global: true,
   })
+  .option('no-skill-check', {
+    describe: 'Skip the automatic skill version check',
+    type: 'boolean',
+    global: true,
+  })
   .middleware(async (argv) => {
     // Determine format from flags
     let format = 'auto';
@@ -115,6 +120,19 @@ export const cli = yargs(hideBin(process.argv))
         process.stderr.write('  jsn setup           # Interactive setup\n');
         process.stderr.write(`  jsn auth login ${instance}   # Login to instance\n\n`);
       }
+    }
+
+    // Auto-check skill on every command (fire-and-forget, non-blocking)
+    const skipSkillCheck = ['help', 'version', 'completion', 'skill'].includes(cmd)
+      || process.env.JSN_NO_SKILL_CHECK === '1'
+      || argv['no-skill-check'];
+    if (!skipSkillCheck) {
+      // Fire check but don't await — it runs in background
+      checkSkill().then(result => {
+        if (result && !result.current && result.error) {
+          process.stderr.write(`\n⚠ ${result.error}\n\n`);
+        }
+      }).catch(() => {});
     }
 
     // Print context header for interactive terminals (at the TOP, before command output)

--- a/src/commands/catalog.js
+++ b/src/commands/catalog.js
@@ -10,6 +10,7 @@ export function catalogCmd(wrap) {
     describe: 'Manage Service Catalog items and variables',
     builder: (yargs) => {
       return yargs
+        // ── create-item: Create a new catalog item definition ──
         .command({
           command: 'create-item',
           describe: 'Create a catalog item (sc_cat_item) with variables',
@@ -19,8 +20,51 @@ export function catalogCmd(wrap) {
             .option('description', { type: 'string', describe: 'Full description' })
             .option('category', { alias: 'c', type: 'string', describe: 'Category name (created if missing)' })
             .option('variable', { alias: 'v', type: 'array', describe: 'Variable definition in format "name:type:label" or "name:type" (e.g. "reason:multilinetext:Reason" or "start_date:date")' })
+            .option('variables', { type: 'string', describe: 'JSON object of variable values for submit_produce API (e.g. \'{"quantity":"100","reason":"Need more"}\')' })
             .option('update-set', { type: 'string', describe: 'Update set sys_id or name to capture changes' }),
           handler: wrap(async (argv, app) => {
+            // If --variables is provided, use submit_produce API (request against existing item)
+            if (argv.variables) {
+              let varsObj;
+              try {
+                varsObj = JSON.parse(argv.variables);
+              } catch {
+                throw new Error('--variables must be a valid JSON object, e.g. {"reason":"Need this"}');
+              }
+              // Resolve the catalog item sys_id from name if needed
+              let itemSysID = argv.name;
+              if (!itemSysID.match(/^[a-f0-9]{32}$/i)) {
+                const params = new URLSearchParams();
+                params.set('sysparm_query', `name=${itemSysID}`);
+                params.set('sysparm_limit', '1');
+                params.set('sysparm_fields', 'sys_id');
+                const items = await app.sdk.list('sc_cat_item', params);
+                if (items.length === 0) throw new Error(`Catalog item not found: ${itemSysID}`);
+                const item = items[0];
+                itemSysID = item.sys_id?.value || item.sys_id;
+              }
+              // Submit via submit_produce API
+              const endpoint = `${app.sdk.baseURL}/api/sn_sc/servicecatalog/items/${itemSysID}/submit_produce`;
+              const body = { variables: varsObj };
+              const result = await app.sdk.request(endpoint, {
+                method: 'POST',
+                body: JSON.stringify(body),
+              });
+              const reqID = result?.result?.sys_id || result?.result?.number || '';
+              app.ok({
+                requested_item: reqID,
+                item_id: itemSysID,
+                variables: varsObj,
+              }, {
+                summary: `Request created: ${result?.result?.number || reqID}`,
+                breadcrumbs: [
+                  { action: 'view', cmd: `jsn requests show ${reqID}`, description: 'View the request' },
+                ],
+              });
+              return;
+            }
+
+            // Original create-item flow: create a new catalog item definition
             const name = argv.name;
             const shortDesc = argv['short-description'] || '';
             const description = argv.description || shortDesc;
@@ -60,7 +104,6 @@ export function catalogCmd(wrap) {
             const varDefs = [];
             if (argv.variable) {
               for (const v of argv.variable) {
-                // Parse "label:type" or "name:type" or "name:type:label" etc.
                 const parts = String(v).split(':');
                 if (parts.length >= 2) {
                   const typeName = parts.length >= 2 ? parts[parts.length - 2] : '';
@@ -104,10 +147,130 @@ export function catalogCmd(wrap) {
             });
           }),
         })
+        // ── items: List and show catalog items ──
+        .command({
+          command: 'items <subcommand>',
+          aliases: ['item'],
+          describe: 'Browse catalog items and inspect variables',
+          builder: (y) => y
+            .command({
+              command: 'list',
+              aliases: ['ls'],
+              describe: 'List catalog items',
+              builder: (y) => y
+                .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' })
+                .option('category', { type: 'string', describe: 'Filter by category' }),
+              handler: wrap(async (argv, app) => {
+                let query = 'ORDERBYname';
+                if (argv.category) query = `category.titleLIKE${argv.category}^${query}`;
+                const params = new URLSearchParams();
+                params.set('sysparm_query', query);
+                params.set('sysparm_limit', String(argv.limit));
+                params.set('sysparm_display_value', 'all');
+                params.set('sysparm_fields', 'sys_id,name,short_description,category,active');
+                const items = await app.sdk.list('sc_cat_item', params);
+                app.ok({
+                  table: 'sc_cat_item',
+                  count: items.length,
+                  columns: ['name', 'short_description', 'category', 'active'],
+                  records: items.map(r => ({
+                    sys_id: r.sys_id?.value || r.sys_id,
+                    name: r.name?.display_value || r.name,
+                    short_description: r.short_description?.display_value || r.short_description || '',
+                    category: r.category?.display_value || '',
+                    active: r.active?.display_value || r.active,
+                  })),
+                  context: { instance_url: app.getEffectiveInstance() },
+                }, { summary: `${items.length} catalog item(s)` });
+              }),
+            })
+            .command({
+              command: 'show <id>',
+              describe: 'Show a catalog item with variables and variable sets',
+              handler: wrap(async (argv, app) => {
+                let itemID = argv.id;
+                // Resolve name to sys_id
+                if (!itemID.match(/^[a-f0-9]{32}$/i)) {
+                  const params = new URLSearchParams();
+                  params.set('sysparm_query', `name=${itemID}`);
+                  params.set('sysparm_limit', '1');
+                  params.set('sysparm_fields', 'sys_id,name');
+                  const items = await app.sdk.list('sc_cat_item', params);
+                  if (items.length === 0) throw new Error(`Catalog item not found: ${itemID}`);
+                  itemID = items[0].sys_id?.value || items[0].sys_id;
+                }
+
+                // Get the catalog item
+                const item = await app.sdk.get('sc_cat_item', itemID);
+
+                // Get variables (item_option_new) for this catalog item
+                const varParams = new URLSearchParams();
+                varParams.set('sysparm_query', `cat_item=${itemID}^active=true`);
+                varParams.set('sysparm_limit', '100');
+                varParams.set('sysparm_display_value', 'all');
+                varParams.set('sysparm_fields', 'sys_id,name,question_text,type,order,mandatory,variable_set');
+                const variables = await app.sdk.list('item_option_new', varParams);
+
+                // Separate standalone vs variable-set variables
+                const standaloneVars = [];
+                const setVars = new Map(); // set_sys_id -> { name, label, variables: [] }
+                for (const v of variables) {
+                  const vs = v.variable_set?.value || v.variable_set;
+                  const entry = {
+                    sys_id: v.sys_id?.value || v.sys_id,
+                    name: v.name?.value || v.name || '',
+                    question_text: v.question_text?.display_value || v.question_text || '',
+                    type: v.type?.display_value || v.type,
+                    order: v.order?.display_value || v.order,
+                    mandatory: v.mandatory?.display_value || v.mandatory,
+                  };
+                  if (vs) {
+                    if (!setVars.has(vs)) {
+                      setVars.set(vs, { name: vs, label: vs, variables: [] });
+                    }
+                    setVars.get(vs).variables.push(entry);
+                  } else {
+                    standaloneVars.push(entry);
+                  }
+                }
+
+                // Try to resolve variable set names
+                for (const [sysID, setData] of setVars) {
+                  try {
+                    const vsRecord = await app.sdk.get('sc_cat_item_option_set', sysID);
+                    setData.name = vsRecord.name?.value || vsRecord.name || sysID;
+                    setData.label = vsRecord.label?.value || vsRecord.label || setData.name;
+                    setData.order = vsRecord.order?.display_value || vsRecord.order;
+                  } catch {
+                    // Can't resolve, keep sys_id as name
+                  }
+                }
+
+                app.ok({
+                  sys_id: itemID,
+                  name: item.name?.display_value || item.name,
+                  short_description: item.short_description?.display_value || item.short_description || '',
+                  description: item.description?.display_value || item.description || '',
+                  category: item.category?.display_value || '',
+                  active: item.active?.display_value || item.active,
+                  variables: {
+                    standalone: standaloneVars,
+                    variable_sets: Array.from(setVars.values()),
+                  },
+                  instance_url: app.getEffectiveInstance(),
+                }, {
+                  summary: `${item.name?.display_value || item.name} — ${standaloneVars.length + Array.from(setVars.values()).reduce((a, s) => a + s.variables.length, 0)} variable(s)`,
+                });
+              }),
+            })
+            .demandCommand(1, 'Specify a subcommand: list or show'),
+          handler: () => {},
+        })
+        // ── list-items: Legacy alias ──
         .command({
           command: 'list-items',
           aliases: ['ls'],
-          describe: 'List catalog items',
+          describe: 'List catalog items (use "catalog items list" instead)',
           builder: (y) => y
             .option('limit', { alias: 'l', type: 'number', default: 20, describe: 'Max records' })
             .option('category', { type: 'string', describe: 'Filter by category' }),
@@ -140,8 +303,9 @@ export function catalogCmd(wrap) {
       if (!argv._[1]) {
         console.log('Manage Service Catalog items.\n');
         console.log('Commands:');
-        console.log('  create-item    Create a catalog item (fast scaffold)');
-        console.log('  list-items     List catalog items');
+        console.log('  create-item    Create a catalog item, or submit a request via submit_produce');
+        console.log('  items list     List catalog items');
+        console.log('  items show     Show catalog item details with variables');
         console.log('\nExamples:');
         console.log('  jsn catalog create-item "Request PTO" \\');
         console.log('    --category "Time Off" \\');
@@ -149,6 +313,10 @@ export function catalogCmd(wrap) {
         console.log('    --variable "start_date:date:Start Date" \\');
         console.log('    --variable "type:select:Type" \\');
         console.log('    --variable "reason:multilinetext:Reason/Notes"');
+        console.log('');
+        console.log('  # Submit a request via submit_produce:');
+        console.log('  jsn catalog create-item "Minecraft Coins" \\');
+        console.log('    --variables \'{"quantity":"100","reason":"Server upgrade"}\'');
         console.log('\nVariable types: string, multilinetext, select, date, datetime, reference, checkbox, email');
         console.log('\nRun "jsn catalog <command> --help" for details.');
       }

--- a/src/commands/skill.js
+++ b/src/commands/skill.js
@@ -18,6 +18,28 @@ function readBundledSkill() {
   }
 }
 
+export async function checkSkill() {
+  const bundled = readBundledSkill();
+  if (!bundled) return { current: false, error: 'Skill file not found in package' };
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 10000);
+    const res = await fetch(SKILL_RAW_URL, { signal: controller.signal });
+    clearTimeout(timer);
+    if (!res.ok) return { current: false, error: `GitHub returned ${res.status}` };
+    const upstream = await res.text();
+    const current = bundled === upstream;
+    return {
+      current,
+      bundled_lines: bundled.split('\n').length,
+      upstream_lines: upstream.split('\n').length,
+      error: current ? null : 'Bundled skill is outdated — run "jsn skill install" to update',
+    };
+  } catch {
+    return { current: false, error: 'Could not check — GitHub unreachable' };
+  }
+}
+
 export function skillCmd(wrap) {
   return {
     command: 'skill',
@@ -41,13 +63,26 @@ export function skillCmd(wrap) {
           }),
         })
         .command({
+          command: 'check',
+          describe: 'Check if the bundled skill file is up to date with GitHub',
+          handler: wrap(async (_argv, app) => {
+            const result = await checkSkill();
+            if (result.error && !result.current) {
+              app.ok(result, { summary: result.error });
+            } else if (result.current) {
+              app.ok(result, { summary: `✓ Skill is current (${result.bundled_lines} lines)` });
+            } else {
+              app.ok(result, { summary: `⚠ Skill is outdated (bundled ${result.bundled_lines} lines vs upstream ${result.upstream_lines} lines) — run "jsn skill install" to update` });
+            }
+          }),
+        })
+        .command({
           command: 'fetch',
           describe: 'Download the latest skill file from GitHub to stdout',
           handler: wrap(async (_argv, _app) => {
             const res = await fetch(SKILL_RAW_URL);
             if (!res.ok) throw new Error(`Failed to fetch skill: ${res.status} ${res.statusText}`);
             const content = await res.text();
-            // Print raw content to stdout for pipe/save usage
             process.stdout.write(content);
           }),
         })
@@ -104,6 +139,6 @@ export function skillCmd(wrap) {
           }),
         });
     },
-    handler: () => {}, // Handled by subcommands
+    handler: () => {},
   };
 }


### PR DESCRIPTION
## Changes

### Catalog
- `catalog items list` — browse catalog items with filtering
- `catalog items show <id>` — inspect variables and variable sets (resolves standalone vs set variables)
- `catalog create-item --variables JSON` — submit via ServiceNow's submit_produce API (variable sets handled server-side)

### Skill
- `skill check` — compare bundled SKILL.md byte-for-byte against GitHub, reports current or outdated
- Auto-check middleware runs on every command (except help/version/skill), prints warning if outdated
- Suppress with `--no-skill-check` flag or `JSN_NO_SKILL_CHECK=1` env var

### Version
- bump: 0.2.0 → 2.0.1

5 files changed, 232 insertions, 11 deletions, 128 tests passing, lint clean.