### PR TITLE
feat: implement jsn dev updatesets yolo subcommand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jacebenson/jsn",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,11 @@
 // App context: bundles config, auth, SDK, output, and runtime context
 
+import fs from 'node:fs';
+import path from 'node:path';
 import { AuthManager } from './auth.js';
 import { SDKClient } from './sdk.js';
 import { OutputWriter, FormatAuto, FormatJSON, FormatMarkdown, FormatQuiet, FormatStyled } from './output.js';
-import { getEffectiveInstance } from './config.js';
+import { getEffectiveInstance, globalConfigDir } from './config.js';
 import { extractProfileName } from './helpers.js';
 import { getCurrentUser, getCurrentApplication, getCurrentUpdateSet } from './context.js';
 import { errUsage, errAuth } from './errors.js';
@@ -52,6 +54,13 @@ export class App {
   async printContextHeader() {
     if (!this.getEffectiveInstance() || !this.sdk) return;
     if (process.env.JSN_NO_HEADER) return;
+    // Check for yolo sentinel file (set by `jsn dev updatesets yolo`)
+    try {
+      const yoloFile = path.join(globalConfigDir(), '.yolo');
+      if (fs.existsSync(yoloFile)) return;
+    } catch {
+      // ignore — if we can't check the file, proceed with the header
+    }
     if (this.output.getFormat() === FormatJSON || this.output.getFormat() === FormatQuiet) return;
 
     let userDisplayName = 'Unknown';
@@ -138,7 +147,7 @@ export class App {
           '┃  Or switch to a scoped scope first:                    ┃\n' +
           '┃    jsn dev scopes list                                 ┃\n' +
           '┃                                                        ┃\n' +
-          '┃  (Run jsn updatesets yolo to silence this check)       ┃\n' +
+          '┃  (Run jsn dev updatesets yolo to silence this check)    ┃\n' +
           '┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\x1b[0m\n'
         );
       } else {
@@ -149,7 +158,7 @@ export class App {
           '  ⚠  Default update set in scope [' + scope + ']\n' +
           '  Changes are contained to this scope, but a named\n' +
           '  update set is still recommended for tracking.\n' +
-          '  (Run \x1b[1mjsn updatesets yolo\x1b[22m to silence this warning)\n' +
+          '  (Run \x1b[1mjsn dev updatesets yolo\x1b[22m to silence this warning)\n' +
           '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
           '\x1b[0m' // reset
         );

--- a/src/cli.js
+++ b/src/cli.js
@@ -136,7 +136,9 @@ export const cli = yargs(hideBin(process.argv))
     }
 
     // Print context header for interactive terminals (at the TOP, before command output)
-    if (!['help', 'version', 'completion', 'skill'].includes(cmd)) {
+    const skipHeader = ['help', 'version', 'completion', 'skill'].includes(cmd)
+      || (cmd === 'dev' && argv._[1] === 'updatesets' && argv._[2] === 'yolo');
+    if (!skipHeader) {
       await argv.app.printContextHeader();
     }
   })

--- a/src/commands/dev/updatesets.js
+++ b/src/commands/dev/updatesets.js
@@ -1,4 +1,7 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { formatRecordForDisplay, getStringField, interactiveList } from '../../helpers.js';
+import { globalConfigDir } from '../../config.js';
 
 export function updateSetsCmd(wrap) {
   return {
@@ -162,6 +165,25 @@ export function updateSetsCmd(wrap) {
             });
           }),
         })
+        .command({
+          command: 'yolo',
+          describe: 'Silence the "Default update set" warning for this session',
+          handler: wrap(async (_argv, app) => {
+            const yoloFile = path.join(globalConfigDir(), '.yolo');
+            fs.mkdirSync(path.dirname(yoloFile), { recursive: true });
+            fs.writeFileSync(yoloFile, String(Date.now()), 'utf-8');
+            process.env.JSN_NO_HEADER = '1';
+            app.ok({
+              suppressed: true,
+              yolo_file: yoloFile,
+            }, {
+              summary: '✓ Default update set warnings suppressed for this session',
+              breadcrumbs: [
+                { action: 'show', cmd: 'jsn dev updatesets list', description: 'Verify update sets' },
+              ],
+            });
+          }),
+        })
 
     },
     handler: (argv) => {
@@ -173,7 +195,6 @@ export function updateSetsCmd(wrap) {
         console.log('  set  <name>    Set the current update set');
         console.log('  create         Create a new update set (auto-sets as current)');
         console.log('  complete <name>  Mark an update set as complete (coming soon)');
-        console.log('  yolo           Silence the "Default update set" warning');
         console.log('\nRun "jsn dev updatesets <command> --help" for details.');
         console.log('\nTip: Create an update set first:');
         console.log('  jsn dev updatesets create --name "My Feature"');


### PR DESCRIPTION
## What

The `yolo` command was listed in both the context header banner text and the updatesets help output, but was never actually implemented as a proper yargs subcommand. Running `jsn updatesets yolo` or `jsn dev updatesets yolo` would hit yargs's unknown command handler and produce an error.

## What changed

**src/commands/dev/updatesets.js** — Added a proper `yolo` subcommand that:
- Writes a sentinel file at `~/.config/servicenow/.yolo`
- Sets `process.env.JSN_NO_HEADER = '1'` for the current process
- Prints a confirmation message with suppression status
- Removed the stale manual `yolo` line from the handler help text (yargs auto-generates it now)

**src/app.js** — `printContextHeader()` now checks for the sentinel file in addition to the `JSN_NO_HEADER` env var

**src/cli.js** — Middleware skips the context header when the subcommand is `dev updatesets yolo`, so the first invocation doesn't hit the warning-before-suppression problem

Both banner texts now correctly show `jsn dev updatesets yolo` instead of the old broken `jsn updatesets yolo` path.

## How it works

```bash
# Run once — silences the Default update set warning for this machine
jsn dev updatesets yolo

# Subsequent commands skip the banner (both the profile header and the warning)
# To re-enable: rm ~/.config/servicenow/.yolo
# Or set JSN_NO_HEADER=1 in your shell profile for a permanent fix
```
