### PR TITLE
feat: support --columns '*' to fetch all record fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {

--- a/src/commands/_ticket.js
+++ b/src/commands/_ticket.js
@@ -1,7 +1,7 @@
 // Generic command builder for CRUD operations on a ServiceNow table
 // Used by incidents, changes, requests, tasks, and most dev subcommands
 
-import { getStringField, formatRecordForDisplay, buildQuerySuffix } from '../helpers.js';
+import { getStringField, formatRecordForDisplay, buildQuerySuffix, resolveFieldsParam } from '../helpers.js';
 import search from '@inquirer/search';
 import { isTTY, FormatAuto } from '../output.js';
 
@@ -114,13 +114,13 @@ export function buildTicketCommands(table, displayName, alias, defaultColumns, s
             params.set('sysparm_limit', String(limit));
             params.set('sysparm_offset', String(offset));
             params.set('sysparm_display_value', 'all');
-            const fetchColumns = ['sys_id', ...columns];
-            params.set('sysparm_fields', fetchColumns.join(','));
+            const fields = resolveFieldsParam(columns);
+            if (fields) params.set('sysparm_fields', fields);
             const q = query ? query + '^ORDERBYDESCsys_updated_on' : 'ORDERBYDESCsys_updated_on';
             params.set('sysparm_query', q);
 
             const records = await app.sdk.list(table, params);
-            const displayRecords = records.map(r => formatRecordForDisplay(r, columns));
+            const displayRecords = fields ? records.map(r => formatRecordForDisplay(r, columns)) : records;
 
             const breadcrumbs = [
               { action: 'create', cmd: `jsn ${alias} create --description "..."`, description: `Create a new ${displayName}` },

--- a/src/commands/groupmembers.js
+++ b/src/commands/groupmembers.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, getStringField } from '../helpers.js';
+import { formatRecordForDisplay, getStringField, resolveFieldsParam } from '../helpers.js';
 
 export function groupMembersCmd(wrap) {
   return {
@@ -20,14 +20,15 @@ export function groupMembersCmd(wrap) {
             const params = new URLSearchParams();
             params.set('sysparm_limit', String(argv.limit));
             params.set('sysparm_display_value', 'all');
-            params.set('sysparm_fields', ['sys_id', ...columns].join(','));
+            const fields = resolveFieldsParam(columns);
+            if (fields) params.set('sysparm_fields', fields);
             if (argv.query) params.set('sysparm_query', argv.query);
             const records = await app.sdk.list('sys_user_grmember', params);
             app.ok({
               table: 'sys_user_grmember',
               count: records.length,
               columns,
-              records: records.map(r => formatRecordForDisplay(r, columns)),
+              records: fields ? records.map(r => formatRecordForDisplay(r, columns)) : records,
               context: { instance_url: app.getEffectiveInstance() },
             }, { summary: `${records.length} group member(s)` });
           }),

--- a/src/commands/grouproles.js
+++ b/src/commands/grouproles.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, getStringField } from '../helpers.js';
+import { formatRecordForDisplay, getStringField, resolveFieldsParam } from '../helpers.js';
 
 export function groupRolesCmd(wrap) {
   return {
@@ -20,14 +20,15 @@ export function groupRolesCmd(wrap) {
             const params = new URLSearchParams();
             params.set('sysparm_limit', String(argv.limit));
             params.set('sysparm_display_value', 'all');
-            params.set('sysparm_fields', ['sys_id', ...columns].join(','));
+            const fields = resolveFieldsParam(columns);
+            if (fields) params.set('sysparm_fields', fields);
             if (argv.query) params.set('sysparm_query', argv.query);
             const records = await app.sdk.list('sys_group_has_role', params);
             app.ok({
               table: 'sys_group_has_role',
               count: records.length,
               columns,
-              records: records.map(r => formatRecordForDisplay(r, columns)),
+              records: fields ? records.map(r => formatRecordForDisplay(r, columns)) : records,
               context: { instance_url: app.getEffectiveInstance() },
             }, { summary: `${records.length} group role(s)` });
           }),

--- a/src/commands/groups.js
+++ b/src/commands/groups.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, getStringField, interactiveList } from '../helpers.js';
+import { formatRecordForDisplay, getStringField, interactiveList, resolveFieldsParam } from '../helpers.js';
 
 export function groupsCmd(wrap) {
   return {
@@ -31,14 +31,15 @@ export function groupsCmd(wrap) {
             const params = new URLSearchParams();
             params.set('sysparm_limit', String(argv.limit));
             params.set('sysparm_display_value', 'all');
-            params.set('sysparm_fields', ['sys_id', ...columns].join(','));
+            const fields = resolveFieldsParam(columns);
+            if (fields) params.set('sysparm_fields', fields);
             if (argv.query) params.set('sysparm_query', argv.query);
             const records = await app.sdk.list('sys_user_group', params);
             app.ok({
               table: 'sys_user_group',
               count: records.length,
               columns,
-              records: records.map(r => formatRecordForDisplay(r, columns)),
+              records: fields ? records.map(r => formatRecordForDisplay(r, columns)) : records,
               context: { instance_url: app.getEffectiveInstance() },
             }, { summary: `${records.length} group(s)` });
           }),

--- a/src/commands/records.js
+++ b/src/commands/records.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, buildQuerySuffix, parseDataArg, getStringField, interactiveList } from '../helpers.js';
+import { formatRecordForDisplay, buildQuerySuffix, parseDataArg, getStringField, interactiveList, resolveFieldsParam } from '../helpers.js';
 
 const tableDefaultColumns = {
   incident: ['number', 'short_description', 'priority', 'state', 'assigned_to'],
@@ -66,10 +66,11 @@ export function recordsCmd(wrap) {
             params.set('sysparm_limit', argv['sys-id'] ? '1' : String(argv.limit));
             params.set('sysparm_offset', String(argv.offset));
             params.set('sysparm_display_value', 'all');
-            params.set('sysparm_fields', ['sys_id', ...columns].join(','));
+            const fields = resolveFieldsParam(columns);
+            if (fields) params.set('sysparm_fields', fields);
             if (query) params.set('sysparm_query', query);
             const records = await app.sdk.list(table, params);
-            const displayRecords = records.map(r => formatRecordForDisplay(r, columns));
+            const displayRecords = fields ? records.map(r => formatRecordForDisplay(r, columns)) : records;
             const breadcrumbs = [
               { action: 'create', cmd: `jsn records create --table ${table} --data '{...}'`, description: 'Create a new record' },
               { action: 'filter', cmd: `jsn records list --table ${table} --query "priority=1"`, description: 'Filter: priority 1 only' },
@@ -118,7 +119,7 @@ export function recordsCmd(wrap) {
             params.set('sysparm_query', `sys_id=${argv['sys-id']}`);
             params.set('sysparm_limit', '1');
             params.set('sysparm_display_value', 'true');
-            if (argv.columns) params.set('sysparm_fields', argv.columns);
+            if (argv.columns && argv.columns !== '*') params.set('sysparm_fields', argv.columns);
             const records = await app.sdk.list(argv.table, params);
             if (records.length === 0) {
               throw new Error(`Record not found: ${argv['sys-id']}`);

--- a/src/commands/tickets.js
+++ b/src/commands/tickets.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, getStringField, buildQuerySuffix } from '../helpers.js';
+import { formatRecordForDisplay, getStringField, buildQuerySuffix, resolveFieldsParam } from '../helpers.js';
 
 export function ticketsCmd(wrap) {
   return {
@@ -22,11 +22,12 @@ export function ticketsCmd(wrap) {
             params.set('sysparm_limit', String(argv.limit));
             params.set('sysparm_offset', String(argv.offset));
             params.set('sysparm_display_value', 'all');
-            params.set('sysparm_fields', ['sys_id', ...columns].join(','));
+            const fields = resolveFieldsParam(columns);
+            if (fields) params.set('sysparm_fields', fields);
             const q = argv.query ? argv.query + '^ORDERBYDESCsys_updated_on' : 'ORDERBYDESCsys_updated_on';
             params.set('sysparm_query', q);
             const records = await app.sdk.list('ticket', params);
-            const displayRecords = records.map(r => formatRecordForDisplay(r, columns));
+            const displayRecords = fields ? records.map(r => formatRecordForDisplay(r, columns)) : records;
             const breadcrumbs = [
               { action: 'create', cmd: 'jsn tickets create --data \'{...}\'', description: 'Create a new ticket' },
             ];

--- a/src/commands/users.js
+++ b/src/commands/users.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, getStringField, interactiveList } from '../helpers.js';
+import { formatRecordForDisplay, getStringField, interactiveList, resolveFieldsParam } from '../helpers.js';
 
 export function usersCmd(wrap) {
   return {
@@ -31,14 +31,15 @@ export function usersCmd(wrap) {
             const params = new URLSearchParams();
             params.set('sysparm_limit', String(argv.limit));
             params.set('sysparm_display_value', 'all');
-            params.set('sysparm_fields', ['sys_id', ...columns].join(','));
+            const fields = resolveFieldsParam(columns);
+            if (fields) params.set('sysparm_fields', fields);
             if (argv.query) params.set('sysparm_query', argv.query);
             const records = await app.sdk.list('sys_user', params);
             app.ok({
               table: 'sys_user',
               count: records.length,
               columns,
-              records: records.map(r => formatRecordForDisplay(r, columns)),
+              records: fields ? records.map(r => formatRecordForDisplay(r, columns)) : records,
               context: { instance_url: app.getEffectiveInstance() },
             }, { summary: `${records.length} user(s)` });
           }),

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -64,6 +64,17 @@ export function buildQuerySuffix(query) {
 }
 
 /**
+ * Resolve sysparm_fields value from user-supplied columns.
+ * Returns null when columns includes '*' (signals "fetch all fields"),
+ * so callers should omit sysparm_fields and skip formatRecordForDisplay.
+ * Otherwise returns the fields string with sys_id prepended.
+ */
+export function resolveFieldsParam(columns) {
+  if (columns.includes('*')) return null;
+  return ['sys_id', ...columns].join(',');
+}
+
+/**
  * Shared interactive list helper with search-as-you-type.
  * All list commands that want an interactive TTY picker should use this.
  *
@@ -84,11 +95,12 @@ export async function interactiveList({ app, table, singular, columns, limit = 2
     return null; // not interactive — caller should fall back to text/table
   }
 
-  const pickerColumns = ['sys_id', labelField, ...columns.filter(c => c !== labelField && c !== 'sys_id')];
+  const pickerColumns = ['sys_id', labelField, ...columns.filter(c => c !== labelField && c !== 'sys_id' && c !== '*')];
   const params = new URLSearchParams();
   params.set('sysparm_limit', String(limit));
   params.set('sysparm_display_value', 'all');
-  params.set('sysparm_fields', pickerColumns.join(','));
+  const pickerFields = pickerColumns.join(',');
+  if (pickerFields) params.set('sysparm_fields', pickerFields);
   params.set('sysparm_query', 'ORDERBYDESCsys_updated_on');
 
   const records = await app.sdk.list(table, params);


### PR DESCRIPTION
## Problem

Passing `--columns '*'` to `records list` sends `sysparm_fields=sys_id,*` to the ServiceNow Table API, which silently ignores `*` as an invalid field name and returns **only `sys_id`**. The same issue affects `tickets list`, `incidents list`, `changes list`, `requests list`, `tasks list`, `users list`, `groups list`, `groupmembers list`, `grouproles list`, and `records get`.

## Solution

Treat `--columns '*'` as a signal to **omit `sysparm_fields` entirely** from the API request, letting ServiceNow return its default field set instead of just `sys_id`. Also skips `formatRecordForDisplay` filtering when `*` is used so all returned fields are visible.

### Changes

- **Adds `resolveFieldsParam()` helper** in `helpers.js` — returns `null` when columns includes `*`, otherwise returns the joined fields string with `sys_id` prepended
- **Updates 8 command files** to use the helper and skip field filtering when `*` is active
- **Version bump**: 3.0.0 → 3.0.1

### Usage

```bash
# Before: returned only sys_id
jsn records list --table sc_req_item --columns '*' --limit 2 --json

# After: returns all default ServiceNow fields
jsn records list --table sc_req_item --columns '*' --limit 2 --json
```