### PR TITLE
fix: register updatesets yolo command and fix banner command reference

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -128,7 +128,9 @@ export class App {
     process.stderr.write(`${profileStr} ${userStr} ${scopeStr} ${updateSetStr}\n\n`);
 
     // ⚠️  Warning if in the Default update set
-    if (updateSet && updateSet.toLowerCase().includes('default')) {
+    const profile = this.context.profileName ? this.config.profiles[this.context.profileName] : null;
+    const isYolo = profile?.yolo === true;
+    if (!isYolo && updateSet && updateSet.toLowerCase().includes('default')) {
       const isGlobal = scope === 'global';
       if (isGlobal) {
         // 🔴 HARD WARNING — Global + Default
@@ -146,7 +148,7 @@ export class App {
           '┃  Or switch to a scoped scope first:                    ┃\n' +
           '┃    jsn dev scopes list                                 ┃\n' +
           '┃                                                        ┃\n' +
-          '┃  (Run jsn updatesets yolo to silence this check)       ┃\n' +
+          '┃  (Run jsn dev updatesets yolo to silence this check)    ┃\n' +
           '┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\x1b[0m\n'
         );
       } else {
@@ -157,7 +159,7 @@ export class App {
           '  ⚠  Default update set in scope [' + scope + ']\n' +
           '  Changes are contained to this scope, but a named\n' +
           '  update set is still recommended for tracking.\n' +
-          '  (Run \x1b[1mjsn updatesets yolo\x1b[22m to silence this warning)\n' +
+          '  (Run \x1b[1mjsn dev updatesets yolo\x1b[22m to silence this warning)\n' +
           '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
           '\x1b[0m' // reset
         );

--- a/src/commands/dev/updatesets.js
+++ b/src/commands/dev/updatesets.js
@@ -162,6 +162,21 @@ export function updateSetsCmd(wrap) {
             });
           }),
         })
+        .command({
+          command: 'yolo',
+          aliases: ['silence'],
+          describe: 'Silence the "Default update set" warning for this profile',
+          handler: wrap(async (argv, app) => {
+            const name = app.context.profileName;
+            if (!name) {
+              throw new Error('No active profile to mark as yolo. Run jsn setup first.');
+            }
+            app.config.profiles[name].yolo = true;
+            const { saveConfig } = await import('../../config.js');
+            saveConfig(app.config);
+            app.ok({ profile: name, yolo: true }, { summary: 'Default update set warning silenced for this profile' });
+          }),
+        })
 
     },
     handler: (argv) => {


### PR DESCRIPTION
## Problem

Two bugs in one:

1. The scope warning banner says `jsn updatesets yolo` to silence the check — but that command doesn't exist. The correct path is `jsn dev updatesets yolo`.

2. `yolo` was only mentioned in the fallthrough help text in `updatesets.js`, not registered as an actual yargs command. Running `jsn dev updatesets yolo` would fail with "Unknown command".

## Fix

- **Banner text** (`app.js`): Fixed both the red "Global + Default" warning (line 149) and the yellow scope warning (line 160) to reference `jsn dev updatesets yolo`.
- **Registered yolo command** (`updatesets.js`): Added a proper yargs subcommand that sets `profile.yolo = true` on the active profile and saves the config. Supports alias `silence`.
- **Silence check** (`app.js`): Before showing the warning, checks if the active profile has `yolo: true` and skips the banner if so.

## Usage

```
# One-time silence
jsn dev updatesets yolo
# → ✓ Default update set warning silenced for profile 'my-instance'
\# → Warning never shows again for this profile
```

## Testing

150/154 tests pass (4 pre-existing failures unrelated to this change).

Closes #93-001