### PR TITLE
fix: dev scopes show accepts both scope value and display name

### DIFF
--- a/src/commands/dev/scopes.js
+++ b/src/commands/dev/scopes.js
@@ -47,14 +47,24 @@ export function scopesCmd(wrap) {
         .command({
           command: 'show <scope>',
           aliases: ['get'],
-          describe: 'Show a scope',
+          describe: 'Show a scope by scope value or name',
+          builder: (y) => y
+            .positional('scope', {
+              describe: 'Scope value (e.g. x_417611_daves_o_0) or display name',
+              type: 'string',
+            }),
           handler: wrap(async (argv, app) => {
-            const params = new URLSearchParams();
-            params.set('sysparm_query', `scope=${argv.scope}`);
-            params.set('sysparm_limit', '1');
-            params.set('sysparm_display_value', 'all');
-            const records = await app.sdk.list('sys_scope', params);
-            if (records.length === 0) {
+            let records;
+            // Try by scope value first, then by name
+            for (const queryField of ['scope', 'name']) {
+              const params = new URLSearchParams();
+              params.set('sysparm_query', `${queryField}=${argv.scope}`);
+              params.set('sysparm_limit', '1');
+              params.set('sysparm_display_value', 'all');
+              records = await app.sdk.list('sys_scope', params);
+              if (records.length > 0) break;
+            }
+            if (!records || records.length === 0) {
               throw new Error(`Scope not found: ${argv.scope}`);
             }
             app.ok(records[0], { summary: `Scope ${argv.scope}` });


### PR DESCRIPTION
## Problem

`jsn dev scopes show <scope>` only queries the `scope` field (unique value like `x_417611_daves_o_0`). Passing the display name (e.g. `"Daves Okta Verify"`) returns `Scope not found: Daves Okta Verify`.

## Fix

Made the `show` handler try both `scope` field and `name` field. Queries by `scope=` first, and if no results, falls back to `name=`. Also added a `.positional()` description so `--help` clearly states both options.

```
jsn dev scopes show x_417611_daves_o_0    # works (scope value)
jsn dev scopes show "Daves Okta Verify"    # now works too (display name)
```

## Testing

150/154 tests pass (4 pre-existing failures unrelated).

Closes #93-006