### PR TITLE
fix: clarify eval quoting in --script and --file descriptions

### DIFF
--- a/src/commands/dev/eval.js
+++ b/src/commands/dev/eval.js
@@ -6,8 +6,8 @@ export function evalCmd(wrap) {
     describe: 'Execute background scripts on the instance',
     builder: (yargs) => {
       return yargs
-        .option('script', { alias: 's', type: 'string', describe: 'JavaScript code to execute' })
-        .option('file', { alias: 'f', type: 'string', describe: 'Read script from file' });
+        .option('script', { alias: 's', type: 'string', describe: "JavaScript code to execute (single-quote the script, double quotes inside: --script 'gs.log(\"Hello\")')" })
+        .option('file', { alias: 'f', type: 'string', describe: 'Read script from file (avoids shell quoting issues)' });
     },
     handler: wrap(async (argv, app) => {
       let script;


### PR DESCRIPTION
## Problem

The `--script` flag description just said "JavaScript code to execute" with no guidance on shell quoting. Users who escaped quotes inside single quotes ended up with doubled backslashes and script compilation failures.

## Fix

Updated the `--script` describe text to show the correct quoting pattern:
```
--script 'gs.log("Hello")'
```

Updated the `--file` describe text to mention it avoids shell quoting entirely.

`--file` is the recommended approach for complex scripts since the script is read from disk with zero shell interpretation.

## Testing

150/154 tests pass (4 pre-existing failures unrelated).

Closes #93-009