### PR TITLE
fix: only show scope warning on mutation commands

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import { getEffectiveInstance } from './config.js';
 import { extractProfileName } from './helpers.js';
 import { getCurrentUser, getCurrentApplication, getCurrentUpdateSet } from './context.js';
 import { errUsage, errAuth } from './errors.js';
+import { isMutationCommand } from './mutations.js';
 import process from 'node:process';
 
 
@@ -57,7 +58,7 @@ export class App {
     return getEffectiveInstance(this.config);
   }
 
-  async printContextHeader() {
+  async printContextHeader(argv = {}) {
     if (!this.getEffectiveInstance() || !this.sdk) return;
     if (process.env.JSN_NO_HEADER) return;
     if (this.output.getFormat() === FormatJSON || this.output.getFormat() === FormatQuiet) return;
@@ -127,10 +128,10 @@ export class App {
 
     process.stderr.write(`${profileStr} ${userStr} ${scopeStr} ${updateSetStr}\n\n`);
 
-    // ⚠️  Warning if in the Default update set
+    // ⚠️  Warning if in the Default update set (mutation commands only)
     const profile = this.context.profileName ? this.config.profiles[this.context.profileName] : null;
     const isYolo = profile?.yolo === true;
-    if (!isYolo && updateSet && updateSet.toLowerCase().includes('default')) {
+    if (!isYolo && isMutationCommand(argv) && updateSet && updateSet.toLowerCase().includes('default')) {
       const isGlobal = scope === 'global';
       if (isGlobal) {
         // 🔴 HARD WARNING — Global + Default

--- a/src/cli.js
+++ b/src/cli.js
@@ -156,7 +156,7 @@ export const cli = yargs(hideBin(process.argv))
 
     // Print context header for interactive terminals (at the TOP, before command output)
     if (!['help', 'version', 'completion', 'skill'].includes(cmd)) {
-      await argv.app.printContextHeader();
+      await argv.app.printContextHeader(argv);
     }
   })
   .command(setupCmd(wrap))

--- a/src/mutations.js
+++ b/src/mutations.js
@@ -23,11 +23,32 @@ export const MUTATION_COMMANDS = [
   ['tasks', 'create'],
   ['tasks', 'update'],
   ['tasks', 'delete'],
-  // Dev
+  // Tickets
+  ['tickets', 'create'],
+  ['tickets', 'update'],
+  ['tickets', 'delete'],
+  // Users
+  ['users', 'create'],
+  ['users', 'update'],
+  ['users', 'delete'],
+  // Groups
+  ['groups', 'create'],
+  ['groups', 'update'],
+  ['groups', 'delete'],
+  // Catalog
+  ['catalog', 'create-item'],
+  // Dev flows
+  ['dev', 'flows', 'create'],
+  ['dev', 'flows', 'update'],
+  ['dev', 'flows', 'delete'],
+  // Dev scopes
+  ['dev', 'scopes', 'create'],
+  ['dev', 'scopes', 'set'],
+  // Dev eval
   ['dev', 'eval'],
+  // Dev updatesets
   ['dev', 'updatesets', 'set'],
   ['dev', 'updatesets', 'create'],
-  ['dev', 'scopes', 'set'],
 ];
 
 /**


### PR DESCRIPTION
## Problem

The scope warning banner (\"You are in Global scope with the Default update set\") appears on EVERY command — including read-only operations like `list`, `show`, and `get`. It should only appear on mutation commands that could actually create or modify records.

## Fix

Three changes:

1. **`app.js`** — `printContextHeader()` now accepts `argv` and only shows the warning when `isMutationCommand(argv)` returns true. Read-only commands silently skip the banner.

2. **`cli.js`** — Passes `argv` to `printContextHeader(argv)`.

3. **`mutations.js`** — Expanded the mutation command registry to cover all commands that mutate data: `tickets`, `users`, `groups`, `catalog create-item`, `dev flows` and `dev scopes create`.

The existing `yolo` per-profile silence flag still works alongside this — it's just no longer needed for read-only commands.

## Testing

150/154 tests pass (4 pre-existing failures unrelated).
A read-only command like `incidents list` no longer shows the warning banner.

Closes #93-005