### PR TITLE
test: add unit tests for tickets command and new mutation commands

### DIFF
--- a/test/mutations.test.js
+++ b/test/mutations.test.js
@@ -55,4 +55,53 @@ describe('mutations.js', () => {
   it('should handle empty argv', () => {
     assert.strictEqual(isMutationCommand({ _: [] }), false);
   });
+
+  // New commands from #97, #100, #102
+  it('should detect tickets create as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['tickets', 'create'] }), true);
+  });
+
+  it('should detect tickets update as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['tickets', 'update'] }), true);
+  });
+
+  it('should detect tickets delete as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['tickets', 'delete'] }), true);
+  });
+
+  it('should not detect tickets list as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['tickets', 'list'] }), false);
+  });
+
+  it('should detect users create as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['users', 'create'] }), true);
+  });
+
+  it('should not detect users list as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['users', 'list'] }), false);
+  });
+
+  it('should detect groups delete as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['groups', 'delete'] }), true);
+  });
+
+  it('should detect catalog create-item as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['catalog', 'create-item'] }), true);
+  });
+
+  it('should not detect catalog list-items as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['catalog', 'list-items'] }), false);
+  });
+
+  it('should detect dev flows create as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['dev', 'flows', 'create'] }), true);
+  });
+
+  it('should not detect dev flows list as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['dev', 'flows', 'list'] }), false);
+  });
+
+  it('should detect dev scopes create as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['dev', 'scopes', 'create'] }), true);
+  });
 });

--- a/test/tickets.test.js
+++ b/test/tickets.test.js
@@ -1,0 +1,26 @@
+// Tests for tickets command — structure tests
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+describe('Tickets Command Structure', () => {
+  it('should export ticketsCmd', async () => {
+    const { ticketsCmd } = await import('../src/commands/tickets.js');
+    assert.strictEqual(typeof ticketsCmd, 'function');
+  });
+
+  it('should define all CRUD subcommands', async () => {
+    const { ticketsCmd } = await import('../src/commands/tickets.js');
+    const wrap = (fn) => fn;
+    const cmd = ticketsCmd(wrap);
+    const subcommands = [];
+    const mockYargs = { command: (c) => { subcommands.push(typeof c === 'string' ? c : c.command); return mockYargs; } };
+    cmd.builder(mockYargs);
+    const names = subcommands.map(s => s.split(' ')[0]);
+    assert.ok(names.includes('list'));
+    assert.ok(names.includes('show'));
+    assert.ok(names.includes('create'));
+    assert.ok(names.includes('update'));
+    assert.ok(names.includes('delete'));
+  });
+});


### PR DESCRIPTION
## Summary

Adds 14 new tests (168 total) to cover the changes from PRs #97 and #102.

### test/mutations.test.js — 12 new tests

Verifies the expanded mutation command registry correctly identifies:
- `tickets create/update/delete` as mutations, `tickets list` as read-only
- `users create` as mutation, `users list` as read-only
- `groups delete` as mutation
- `catalog create-item` as mutation, `catalog list-items` as read-only
- `dev flows create` as mutation, `dev flows list` as read-only
- `dev scopes create` as mutation

### test/tickets.test.js — 2 new tests (new file)

Verifies `ticketsCmd` exports properly and defines all CRUD subcommands (list, show, create, update, delete).

## Test Results

168 tests, 164 pass, 4 pre-existing failures (auth/config-dependent).