### PR TITLE
fix: improve profile CLI UX (--profile no-arg, help text)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -185,6 +185,25 @@ export const cli = yargs(hideBin(process.argv))
     if (err) throw err;
     // No command given → show custom grouped help instead of yargs error
     if (msg === 'You must specify a command') {
+      // Check if --profile/-p was used without a value — show profile info instead
+      const raw = process.argv.slice(2);
+      const hasLoneProfile = raw.some((a, i, arr) => {
+        if (a !== '--profile' && a !== '-p') return false;
+        const next = arr[i + 1];
+        return !next || next.startsWith('-');
+      });
+      if (hasLoneProfile) {
+        const cfg = loadConfig();
+        const activeName = cfg.activeProfile || cfg.defaultProfile;
+        process.stdout.write('Profiles:\n');
+        for (const [name, p] of Object.entries(cfg.profiles || {})) {
+          const marker = name === activeName ? ' *' : '  ';
+          process.stdout.write(`  ${marker} ${name.padEnd(20)} ${p.instance_url || ''}\n`);
+        }
+        process.stdout.write('\nUsage: jsn --profile <name> <command>\n');
+        process.stdout.write('       jsn profiles use <name>\n');
+        process.exit(0);
+      }
       process.stdout.write(renderHelp());
       process.exit(0);
     }

--- a/src/commands/profiles.js
+++ b/src/commands/profiles.js
@@ -181,6 +181,9 @@ export function profilesCmd(wrap) {
         console.log('  use  <name>    Switch to a different profile');
         console.log('  remove <name>  Remove a profile');
         console.log('\nRun "jsn profiles <command> --help" for more details.');
+        console.log('\nNote: You can also create a profile by authenticating:');
+        console.log('  jsn auth login --profile <name> <instance-url>');
+        console.log('  jsn auth login --profile staging --password https://dev12345.service-now.com');
       }
     },
   };


### PR DESCRIPTION
## Changes

### #88 — `jsn --profile` (no arg) shows profile info instead of full help

Before: `jsn --profile` without a value dumped the entire grouped command help page.

After: Shows current profiles and usage hint:
```
Profiles:
   * dev227772            https://dev227772.service-now.com

Usage: jsn --profile <name> <command>
       jsn profiles use <name>
```

Also handles `-p` alias.

### #87 — Profile creation discoverability

Added a note at the bottom of `jsn profiles --help` mentioning that profiles can also be created via authentication:
```
Note: You can also create a profile by authenticating:
  jsn auth login --profile <name> <instance-url>
  jsn auth login --profile staging --password https://dev12345.service-now.com
```

## Testing

148/154 tests pass (6 pre-existing failures — config-dependent, unchanged by this PR).
Manual verification of `jsn`, `jsn --profile`, `jsn -p`, and `jsn --profile <valid> <cmd>` all produce correct output.

Closes #88, Closes #87