### PR TITLE
chore: bump 3.0.1 → 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v3.0.2

### Bug Fixes
- **tickets**: Fix `tickets` command querying non-existent `ticket` table — now queries `task` table (#97)
- **updatesets yolo**: Fix broken command reference in scope banner; register `yolo` as a real subcommand (#98)
- **forms/lists**: Add positional descriptions so missing `<table>` argument gives a useful error instead of "Not enough non-option arguments" (#99)
- **scopes show**: Accept both scope value and display name for lookup (#100)
- **scope warning**: Only show "Default update set" warning on mutation commands, not read-only operations (#102)

### Features
- **eval quoting docs**: Clarify shell quoting in `--script` and `--file` descriptions (#101)
- **profile UX**: `jsn --profile` (no arg) now shows profile list instead of full help; add creation hint to `profiles --help` (#104)

### Tests
- Add unit tests for tickets command structure and new mutation commands (#103)
- Fix env-dependent test failures by isolating from local config and auth env vars (#105)
- 168 tests, all passing