### PR TITLE
feat: add records inspect command for audit history, business rules, and running flows

### DIFF
--- a/src/commands/dev/flows.js
+++ b/src/commands/dev/flows.js
@@ -25,7 +25,7 @@ export function flowsCmd(wrap) {
               formatLabel: r => `${getStringField(r, 'name')} ${getStringField(r, 'active') === 'true' ? '' : '[inactive]'}`,
             });
             if (picked) {
-              const inspection = await app.sdk.inspectFlow(picked.sys_id);
+              const inspection = await app.sdk.inspectFlow(getStringField(picked, 'sys_id'));
               const formatted = formatFlowInspection(inspection, app.getEffectiveInstance());
               return app.ok({ ...inspection, _formatted: formatted }, {
                 summary: `Flow: ${inspection.flow.name}`,

--- a/src/commands/records.js
+++ b/src/commands/records.js
@@ -175,11 +175,18 @@ export function recordsCmd(wrap) {
           handler: wrap(async (argv, app) => {
             const { inspectRecord, formatInspectOutput } = await import('../records/inspect.js');
             const result = await inspectRecord(app, argv.table, argv.identifier);
-            const breadcrumbs = result.flows.map(f => ({
-              action: 'show',
-              cmd: `jsn dev flows show "${f.flow}"`,
-              description: `View flow details for ${f.flow}`,
-            }));
+            const breadcrumbs = [
+              ...result.flows.map(f => ({
+                action: 'show',
+                cmd: `jsn dev flows show "${f.flow}"`,
+                description: `View flow details for ${f.flow}`,
+              })),
+              ...result.businessRules.slice(0, 5).map(br => ({
+                action: 'show',
+                cmd: `jsn dev rules show "${br.name}"`,
+                description: `View business rule: ${br.name}`,
+              })),
+            ];
             app.ok({ ...result, _formatted: formatInspectOutput(result) }, {
               summary: `Inspected ${argv.table} ${argv.identifier}`,
               breadcrumbs,

--- a/src/commands/records.js
+++ b/src/commands/records.js
@@ -165,6 +165,19 @@ export function recordsCmd(wrap) {
             app.ok({ message: 'Record deleted', table: argv.table, sys_id: argv['sys-id'] }, { summary: `Deleted record from ${argv.table}` });
           }),
         })
+        .command({
+          command: 'inspect <table> <identifier>',
+          aliases: ['debug', 'diag'],
+          describe: 'Inspect a record: show audit history, business rules, and running flows',
+          builder: (y) => y
+            .positional('table', { describe: 'Table name (e.g. incident)', type: 'string' })
+            .positional('identifier', { describe: 'Record sys_id or number', type: 'string' }),
+          handler: wrap(async (argv, app) => {
+            const { inspectRecord } = await import('../records/inspect.js');
+            const result = await inspectRecord(app, argv.table, argv.identifier);
+            app.ok(result, { summary: `Inspected ${argv.table} ${argv.identifier}` });
+          }),
+        })
 
     },
     handler: () => {},

--- a/src/commands/records.js
+++ b/src/commands/records.js
@@ -173,9 +173,9 @@ export function recordsCmd(wrap) {
             .positional('table', { describe: 'Table name (e.g. incident)', type: 'string' })
             .positional('identifier', { describe: 'Record sys_id or number', type: 'string' }),
           handler: wrap(async (argv, app) => {
-            const { inspectRecord } = await import('../records/inspect.js');
+            const { inspectRecord, formatInspectOutput } = await import('../records/inspect.js');
             const result = await inspectRecord(app, argv.table, argv.identifier);
-            app.ok(result, { summary: `Inspected ${argv.table} ${argv.identifier}` });
+            app.ok({ ...result, _formatted: formatInspectOutput(result) }, { summary: `Inspected ${argv.table} ${argv.identifier}` });
           }),
         })
 

--- a/src/commands/records.js
+++ b/src/commands/records.js
@@ -175,7 +175,15 @@ export function recordsCmd(wrap) {
           handler: wrap(async (argv, app) => {
             const { inspectRecord, formatInspectOutput } = await import('../records/inspect.js');
             const result = await inspectRecord(app, argv.table, argv.identifier);
-            app.ok({ ...result, _formatted: formatInspectOutput(result) }, { summary: `Inspected ${argv.table} ${argv.identifier}` });
+            const breadcrumbs = result.flows.map(f => ({
+              action: 'show',
+              cmd: `jsn dev flows show "${f.flow}"`,
+              description: `View flow details for ${f.flow}`,
+            }));
+            app.ok({ ...result, _formatted: formatInspectOutput(result) }, {
+              summary: `Inspected ${argv.table} ${argv.identifier}`,
+              breadcrumbs,
+            });
           }),
         })
 

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -28,8 +28,8 @@ async function fetchHistory(app, table, sysId, limit = 20) {
   const records = await app.sdk.list('sys_audit', params);
   return records.map(r => ({
     field: r.fieldname?.display_value || r.fieldname,
-    oldValue: r.oldvalue?.display_value || r.oldvalue,
-    newValue: r.newvalue?.display_value || r.newvalue,
+    oldValue: (r.oldvalue?.display_value ?? r.oldvalue?.value ?? r.oldvalue) || '',
+    newValue: (r.newvalue?.display_value ?? r.newvalue?.value ?? r.newvalue) || '',
     changedOn: r.sys_created_on?.display_value || r.sys_created_on,
     changedBy: r.sys_created_by?.display_value || r.sys_created_by,
   }));

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -50,11 +50,32 @@ async function fetchBusinessRules(app, table) {
   }));
 }
 
+async function fetchFlows(app, sysId) {
+  const params = new URLSearchParams();
+  params.set('sysparm_query', `source_record=${sysId}`);
+  params.set('sysparm_limit', '20');
+  params.set('sysparm_fields', 'flow_catalog_model,execution_id,state,engine_major_version,sys_created_on,origins');
+  params.set('sysparm_display_value', 'all');
+  try {
+    const records = await app.sdk.list('sys_flow_context', params);
+    return records.map(r => ({
+      flow: r.flow_catalog_model?.display_value || r.flow_catalog_model,
+      executionId: r.execution_id?.display_value || r.execution_id,
+      state: r.state?.display_value || r.state,
+      version: r.engine_major_version?.display_value || r.engine_major_version,
+      started: r.sys_created_on?.display_value || r.sys_created_on,
+    }));
+  } catch {
+    return []; // Flow Designer might not be installed
+  }
+}
+
 export async function inspectRecord(app, table, identifier) {
   const sysId = await resolveIdentifier(app, table, identifier);
-  const [history, businessRules] = await Promise.all([
+  const [history, businessRules, flows] = await Promise.all([
     fetchHistory(app, table, sysId),
     fetchBusinessRules(app, table),
+    fetchFlows(app, sysId),
   ]);
-  return { table, sys_id: sysId, history, businessRules, flows: [] };
+  return { table, sys_id: sysId, history, businessRules, flows };
 }

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -77,7 +77,8 @@ export function formatInspectOutput(data) {
   lines.push('');
 
   // History section
-  lines.push('\u2500\u2500 History \u2500\u2500');
+  lines.push('\u25B6 HISTORY');
+  lines.push('\u2500'.repeat(50));
   if (data.history.length === 0) {
     lines.push('  (no audit history found)');
   } else {
@@ -91,7 +92,8 @@ export function formatInspectOutput(data) {
   lines.push('');
 
   // Business rules section
-  lines.push('\u2500\u2500 Business Rules \u2500\u2500');
+  lines.push('\u25B6 BUSINESS RULES');
+  lines.push('\u2500'.repeat(50));
   if (data.businessRules.length === 0) {
     lines.push('  (no active business rules on this table)');
   } else {
@@ -102,12 +104,16 @@ export function formatInspectOutput(data) {
   lines.push('');
 
   // Flows section
-  lines.push('\u2500\u2500 Running Flows \u2500\u2500');
+  lines.push('\u25B6 RUNNING FLOWS');
+  lines.push('\u2500'.repeat(50));
   if (data.flows.length === 0) {
     lines.push('  (no running flows for this record)');
   } else {
     for (const f of data.flows) {
-      lines.push(`  ${f.flow}  [${f.state}]  v${f.version}`);
+      lines.push(`  Flow: ${f.flow}`);
+      lines.push(`  Status: ${f.state} | Version: ${f.version}`);
+      if (f.started) lines.push(`  Started: ${f.started}`);
+      lines.push('');
     }
   }
   lines.push('');

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -60,12 +60,12 @@ async function fetchFlows(app, sysId) {
   const params = new URLSearchParams();
   params.set('sysparm_query', `source_record=${sysId}`);
   params.set('sysparm_limit', '20');
-  params.set('sysparm_fields', 'flow_catalog_model,execution_id,state,engine_major_version,sys_created_on,origins');
+  params.set('sysparm_fields', 'flow_catalog_model,name,execution_id,state,engine_major_version,sys_created_on,origins,calling_source');
   params.set('sysparm_display_value', 'all');
   try {
     const records = await app.sdk.list('sys_flow_context', params);
     return records.map(r => ({
-      flow: r.flow_catalog_model?.display_value || r.flow_catalog_model?.value || '(deleted flow)',
+      flow: r.name?.display_value || r.name || r.flow_catalog_model?.display_value || r.flow_catalog_model?.value || '(deleted flow)',
       executionId: r.execution_id?.display_value || r.execution_id,
       state: r.state?.display_value || r.state,
       version: r.engine_major_version?.display_value || r.engine_major_version,

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -209,12 +209,28 @@ export function formatInspectOutput(data) {
   if (data.businessRules.length === 0) {
     lines.push('  (no active business rules on this table)');
   } else {
+    // Group by execution phase: before → display → after → async
+    const phases = ['before', 'display', 'after', 'async'];
+    const grouped = {};
     for (const br of data.businessRules) {
-      const whenTag = br.when ? ` [${br.when}]` : '';
-      lines.push(`  [${br.order}]${whenTag} ${br.name}${br.scope !== 'global' ? ` (${br.scope})` : ''}`);
-      if (br.condition) {
-        const cond = br.condition.length > 80 ? br.condition.substring(0, 77) + '...' : br.condition;
-        lines.push(`       Condition: ${cond}`);
+      const phase = br.when?.toLowerCase() || '';
+      if (!grouped[phase]) grouped[phase] = [];
+      grouped[phase].push(br);
+    }
+    for (const phase of phases) {
+      const rules = grouped[phase]?.sort((a, b) => {
+        const aOrder = parseInt(String(a.order).replace(/,/g, ''), 10) || 0;
+        const bOrder = parseInt(String(b.order).replace(/,/g, ''), 10) || 0;
+        return aOrder - bOrder;
+      });
+      if (!rules || rules.length === 0) continue;
+      lines.push(`  ${phase.charAt(0).toUpperCase() + phase.slice(1)}:`);
+      for (const br of rules) {
+        lines.push(`    [${br.order}] ${br.name}${br.scope !== 'global' ? ` (${br.scope})` : ''}`);
+        if (br.condition) {
+          const cond = br.condition.length > 80 ? br.condition.substring(0, 77) + '...' : br.condition;
+          lines.push(`       Condition: ${cond}`);
+        }
       }
     }
   }

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -18,7 +18,27 @@ export async function resolveIdentifier(app, table, identifier) {
   return getStringField(records[0], 'sys_id');
 }
 
+async function fetchHistory(app, table, sysId, limit = 20) {
+  const params = new URLSearchParams();
+  params.set('sysparm_query', `documentkey=${sysId}^tablename=${table}`);
+  params.set('sysparm_limit', String(limit));
+  params.set('sysparm_fields', 'fieldname,newvalue,oldvalue,sys_created_on,sys_created_by');
+  params.set('sysparm_display_value', 'all');
+  params.set('sysparm_order_by', 'sys_created_on');
+  const records = await app.sdk.list('sys_audit', params);
+  return records.map(r => ({
+    field: r.fieldname?.display_value || r.fieldname,
+    oldValue: r.oldvalue?.display_value || r.oldvalue,
+    newValue: r.newvalue?.display_value || r.newvalue,
+    changedOn: r.sys_created_on?.display_value || r.sys_created_on,
+    changedBy: r.sys_created_by?.display_value || r.sys_created_by,
+  }));
+}
+
 export async function inspectRecord(app, table, identifier) {
   const sysId = await resolveIdentifier(app, table, identifier);
-  return { table, sys_id: sysId, history: [], businessRules: [], flows: [] };
+  const [history] = await Promise.all([
+    fetchHistory(app, table, sysId),
+  ]);
+  return { table, sys_id: sysId, history, businessRules: [], flows: [] };
 }

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -70,6 +70,51 @@ async function fetchFlows(app, sysId) {
   }
 }
 
+export function formatInspectOutput(data) {
+  const lines = [];
+  lines.push('');
+  lines.push(`\u{1F4CB} ${data.table}  ${data.sys_id}`);
+  lines.push('');
+
+  // History section
+  lines.push('\u2500\u2500 History \u2500\u2500');
+  if (data.history.length === 0) {
+    lines.push('  (no audit history found)');
+  } else {
+    for (const h of data.history.slice(0, 10)) {
+      lines.push(`  ${h.changedOn}  ${h.changedBy}  ${h.field}: ${h.oldValue || '(empty)'} \u2192 ${h.newValue}`);
+    }
+    if (data.history.length > 10) {
+      lines.push(`  ... and ${data.history.length - 10} more`);
+    }
+  }
+  lines.push('');
+
+  // Business rules section
+  lines.push('\u2500\u2500 Business Rules \u2500\u2500');
+  if (data.businessRules.length === 0) {
+    lines.push('  (no active business rules on this table)');
+  } else {
+    for (const br of data.businessRules) {
+      lines.push(`  [${br.order}] ${br.name}${br.scope !== 'global' ? ` (${br.scope})` : ''}`);
+    }
+  }
+  lines.push('');
+
+  // Flows section
+  lines.push('\u2500\u2500 Running Flows \u2500\u2500');
+  if (data.flows.length === 0) {
+    lines.push('  (no running flows for this record)');
+  } else {
+    for (const f of data.flows) {
+      lines.push(`  ${f.flow}  [${f.state}]  v${f.version}`);
+    }
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
 export async function inspectRecord(app, table, identifier) {
   const sysId = await resolveIdentifier(app, table, identifier);
   const [history, businessRules, flows] = await Promise.all([

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -35,10 +35,26 @@ async function fetchHistory(app, table, sysId, limit = 20) {
   }));
 }
 
+async function fetchBusinessRules(app, table) {
+  const params = new URLSearchParams();
+  params.set('sysparm_query', `collection=${table}^active=true`);
+  params.set('sysparm_limit', '50');
+  params.set('sysparm_fields', 'name,collection,order,active,sys_scope');
+  params.set('sysparm_display_value', 'all');
+  params.set('sysparm_order_by', 'order');
+  const records = await app.sdk.list('sys_script', params);
+  return records.map(r => ({
+    name: r.name?.display_value || r.name,
+    order: r.order?.display_value || r.order,
+    scope: r.sys_scope?.display_value || r.sys_scope || 'global',
+  }));
+}
+
 export async function inspectRecord(app, table, identifier) {
   const sysId = await resolveIdentifier(app, table, identifier);
-  const [history] = await Promise.all([
+  const [history, businessRules] = await Promise.all([
     fetchHistory(app, table, sysId),
+    fetchBusinessRules(app, table),
   ]);
-  return { table, sys_id: sysId, history, businessRules: [], flows: [] };
+  return { table, sys_id: sysId, history, businessRules, flows: [] };
 }

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -28,11 +28,115 @@ async function fetchHistory(app, table, sysId, limit = 20) {
   const records = await app.sdk.list('sys_audit', params);
   return records.map(r => ({
     field: r.fieldname?.display_value || r.fieldname,
-    oldValue: (r.oldvalue?.display_value ?? r.oldvalue?.value ?? r.oldvalue) || '',
-    newValue: (r.newvalue?.display_value ?? r.newvalue?.value ?? r.newvalue) || '',
+    oldValue: (r.oldvalue?.display_value ?? r.oldvalue?.value ?? '') || '',
+    newValue: (r.newvalue?.display_value ?? r.newvalue?.value ?? '') || '',
+    _oldRaw: r.oldvalue?.value ?? r.oldvalue ?? '',
+    _newRaw: r.newvalue?.value ?? r.newvalue ?? '',
     changedOn: r.sys_created_on?.display_value || r.sys_created_on,
     changedBy: r.sys_created_by?.display_value || r.sys_created_by,
   }));
+}
+
+// Known choice fields and their display labels from sys_choice
+const CHOICE_FIELDS = new Set(['state', 'incident_state', 'priority', 'impact', 'urgency', 'active', 'category', 'subcategory']);
+
+// Known sys_user reference fields
+const USER_REF_FIELDS = new Set(['closed_by', 'assigned_to', 'opened_by', 'resolved_by', 'called_by', 'caller_id']);
+
+// Boolean fields stored as 0/1 in sys_audit
+const BOOL_FIELDS = new Set(['active']);
+
+async function resolveHistoryDisplayValues(app, table, history) {
+  // Collect unique sys_ids for user reference resolution
+  const userSysIds = new Set();
+  for (const h of history) {
+    if (USER_REF_FIELDS.has(h.field)) {
+      if (isHexString(h.oldValue) && h.oldValue.length === 32) userSysIds.add(h.oldValue);
+      if (isHexString(h.newValue) && h.newValue.length === 32) userSysIds.add(h.newValue);
+    }
+  }
+
+  // Batch lookup user names
+  const userNameMap = new Map();
+  if (userSysIds.size > 0) {
+    const idList = [...userSysIds].join(',');
+    const params = new URLSearchParams();
+    params.set('sysparm_query', `sys_idIN${idList}`);
+    params.set('sysparm_limit', '100');
+    params.set('sysparm_fields', 'sys_id,name');
+    params.set('sysparm_display_value', 'all');
+    try {
+      const users = await app.sdk.list('sys_user', params);
+      for (const u of users) {
+        const uid = getStringField(u, 'sys_id');
+        const name = u.name?.display_value || u.name;
+        if (uid && name) userNameMap.set(uid, name);
+      }
+    } catch { /* non-fatal */ }
+  }
+
+  // Collect unique (field, value) pairs for choice resolution
+  const choiceLookups = new Set();
+  for (const h of history) {
+    if (CHOICE_FIELDS.has(h.field)) {
+      if (h.oldValue && h.oldValue !== '_raw_old_') choiceLookups.add(`${h.field}|${h.oldValue}`);
+      if (h.newValue && h.newValue !== '_raw_new_') choiceLookups.add(`${h.field}|${h.newValue}`);
+    }
+  }
+
+  // Batch lookup choice labels
+  const choiceLabelMap = new Map();
+  if (choiceLookups.size > 0) {
+    for (const key of choiceLookups) {
+      const [field, val] = key.split('|');
+      const params = new URLSearchParams();
+      params.set('sysparm_query', `name=${table}^element=${field}^value=${val}^language=en`);
+      params.set('sysparm_limit', '1');
+      params.set('sysparm_fields', 'value,label');
+      params.set('sysparm_display_value', 'all');
+      try {
+        const choices = await app.sdk.list('sys_choice', params);
+        if (choices.length > 0) {
+          const label = choices[0].label?.display_value || choices[0].label;
+          if (label) choiceLabelMap.set(key, label);
+        }
+      } catch { /* non-fatal */ }
+    }
+  }
+
+  // Apply resolutions to history entries
+  return history.map(h => {
+    let oldDisplay = h.oldValue;
+    let newDisplay = h.newValue;
+
+    // Resolve user references
+    if (USER_REF_FIELDS.has(h.field)) {
+      if (isHexString(oldDisplay) && oldDisplay.length === 32) {
+        oldDisplay = userNameMap.get(oldDisplay) || oldDisplay || '(empty)';
+      }
+      if (isHexString(newDisplay) && newDisplay.length === 32) {
+        newDisplay = userNameMap.get(newDisplay) || newDisplay || '(empty)';
+      }
+    }
+
+    // Resolve choice labels
+    if (CHOICE_FIELDS.has(h.field)) {
+      const oldLabel = choiceLabelMap.get(`${h.field}|${h.oldValue}`);
+      const newLabel = choiceLabelMap.get(`${h.field}|${h.newValue}`);
+      if (oldLabel) oldDisplay = oldLabel;
+      if (newLabel) newDisplay = newLabel;
+    }
+
+    // Resolve boolean fields
+    if (BOOL_FIELDS.has(h.field)) {
+      if (oldDisplay === '1') oldDisplay = 'Yes';
+      else if (oldDisplay === '0') oldDisplay = 'No';
+      if (newDisplay === '1') newDisplay = 'Yes';
+      else if (newDisplay === '0') newDisplay = 'No';
+    }
+
+    return { ...h, oldValue: oldDisplay || '(empty)', newValue: newDisplay || '(empty)' };
+  });
 }
 
 async function fetchBusinessRules(app, table) {
@@ -129,10 +233,11 @@ export function formatInspectOutput(data) {
 
 export async function inspectRecord(app, table, identifier) {
   const sysId = await resolveIdentifier(app, table, identifier);
-  const [history, businessRules, flows] = await Promise.all([
+  const [rawHistory, businessRules, flows] = await Promise.all([
     fetchHistory(app, table, sysId),
     fetchBusinessRules(app, table),
     fetchFlows(app, sysId),
   ]);
+  const history = await resolveHistoryDisplayValues(app, table, rawHistory);
   return { table, sys_id: sysId, history, businessRules, flows };
 }

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -1,3 +1,24 @@
+import { isHexString, getStringField } from '../helpers.js';
+
+export async function resolveIdentifier(app, table, identifier) {
+  // If it looks like a sys_id (32 hex chars), use it directly
+  if (isHexString(identifier) && identifier.length === 32) {
+    return identifier;
+  }
+
+  // Otherwise, assume it's a record number — query the table
+  const params = new URLSearchParams();
+  params.set('sysparm_query', `number=${identifier}`);
+  params.set('sysparm_limit', '1');
+  params.set('sysparm_fields', 'sys_id');
+  const records = await app.sdk.list(table, params);
+  if (records.length === 0) {
+    throw new Error(`Record not found in ${table}: ${identifier}`);
+  }
+  return getStringField(records[0], 'sys_id');
+}
+
 export async function inspectRecord(app, table, identifier) {
-  return { table, identifier, history: [], businessRules: [], flows: [] };
+  const sysId = await resolveIdentifier(app, table, identifier);
+  return { table, sys_id: sysId, history: [], businessRules: [], flows: [] };
 }

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -43,11 +43,17 @@ async function fetchBusinessRules(app, table) {
   params.set('sysparm_display_value', 'all');
   params.set('sysparm_order_by', 'order');
   const records = await app.sdk.list('sys_script', params);
-  return records.map(r => ({
-    name: r.name?.display_value || r.name,
-    order: r.order?.display_value || r.order,
-    scope: r.sys_scope?.display_value || r.sys_scope || 'global',
-  }));
+  return records
+    .map(r => ({
+      name: r.name?.display_value || r.name,
+      order: r.order?.display_value || r.order,
+      scope: r.sys_scope?.display_value || r.sys_scope || 'global',
+    }))
+    .sort((a, b) => {
+      const aOrder = parseInt(String(a.order).replace(/,/g, ''), 10) || 0;
+      const bOrder = parseInt(String(b.order).replace(/,/g, ''), 10) || 0;
+      return aOrder - bOrder;
+    });
 }
 
 async function fetchFlows(app, sysId) {

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -1,0 +1,3 @@
+export async function inspectRecord(app, table, identifier) {
+  return { table, identifier, history: [], businessRules: [], flows: [] };
+}

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -65,7 +65,7 @@ async function fetchFlows(app, sysId) {
   try {
     const records = await app.sdk.list('sys_flow_context', params);
     return records.map(r => ({
-      flow: r.flow_catalog_model?.display_value || r.flow_catalog_model,
+      flow: r.flow_catalog_model?.display_value || r.flow_catalog_model?.value || '(deleted flow)',
       executionId: r.execution_id?.display_value || r.execution_id,
       state: r.state?.display_value || r.state,
       version: r.engine_major_version?.display_value || r.engine_major_version,

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -143,7 +143,7 @@ async function fetchBusinessRules(app, table) {
   const params = new URLSearchParams();
   params.set('sysparm_query', `collection=${table}^active=true`);
   params.set('sysparm_limit', '50');
-  params.set('sysparm_fields', 'name,collection,order,active,sys_scope');
+  params.set('sysparm_fields', 'name,collection,order,active,sys_scope,when,filter_condition');
   params.set('sysparm_display_value', 'all');
   params.set('sysparm_order_by', 'order');
   const records = await app.sdk.list('sys_script', params);
@@ -152,6 +152,8 @@ async function fetchBusinessRules(app, table) {
       name: r.name?.display_value || r.name,
       order: r.order?.display_value || r.order,
       scope: r.sys_scope?.display_value || r.sys_scope || 'global',
+      when: r.when?.display_value || r.when || '',
+      condition: r.filter_condition?.display_value || r.filter_condition?.value || '',
     }))
     .sort((a, b) => {
       const aOrder = parseInt(String(a.order).replace(/,/g, ''), 10) || 0;
@@ -208,7 +210,12 @@ export function formatInspectOutput(data) {
     lines.push('  (no active business rules on this table)');
   } else {
     for (const br of data.businessRules) {
-      lines.push(`  [${br.order}] ${br.name}${br.scope !== 'global' ? ` (${br.scope})` : ''}`);
+      const whenTag = br.when ? ` [${br.when}]` : '';
+      lines.push(`  [${br.order}]${whenTag} ${br.name}${br.scope !== 'global' ? ` (${br.scope})` : ''}`);
+      if (br.condition) {
+        const cond = br.condition.length > 80 ? br.condition.substring(0, 77) + '...' : br.condition;
+        lines.push(`       Condition: ${cond}`);
+      }
     }
   }
   lines.push('');

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { isHexString } from '../src/helpers.js';
+
+describe('inspectRecord', () => {
+  it('should detect 32-char hex string as sys_id', () => {
+    const id = 'ac912768839d4710f7bfc670ceaad358';
+    assert.ok(isHexString(id));
+    assert.strictEqual(id.length, 32);
+  });
+
+  it('should not treat a number as sys_id', () => {
+    assert.strictEqual(isHexString('INC0010001'), false);
+  });
+
+  it('should export inspectRecord function', async () => {
+    const { inspectRecord } = await import('../src/records/inspect.js');
+    assert.strictEqual(typeof inspectRecord, 'function');
+  });
+
+  it('should export resolveIdentifier function', async () => {
+    const { resolveIdentifier } = await import('../src/records/inspect.js');
+    assert.strictEqual(typeof resolveIdentifier, 'function');
+  });
+});

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -22,4 +22,13 @@ describe('inspectRecord', () => {
     const { resolveIdentifier } = await import('../src/records/inspect.js');
     assert.strictEqual(typeof resolveIdentifier, 'function');
   });
+
+  it('should format inspect output for empty data', async () => {
+    const { formatInspectOutput } = await import('../src/records/inspect.js');
+    const result = formatInspectOutput({ table: 'incident', sys_id: 'abc123', history: [], businessRules: [], flows: [] });
+    assert.ok(result.includes('incident'));
+    assert.ok(result.includes('History'));
+    assert.ok(result.includes('Business Rules'));
+    assert.ok(result.includes('Running Flows'));
+  });
 });

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -27,8 +27,8 @@ describe('inspectRecord', () => {
     const { formatInspectOutput } = await import('../src/records/inspect.js');
     const result = formatInspectOutput({ table: 'incident', sys_id: 'abc123', history: [], businessRules: [], flows: [] });
     assert.ok(result.includes('incident'));
-    assert.ok(result.includes('History'));
-    assert.ok(result.includes('Business Rules'));
-    assert.ok(result.includes('Running Flows'));
+    assert.ok(result.includes('HISTORY'));
+    assert.ok(result.includes('BUSINESS RULES'));
+    assert.ok(result.includes('RUNNING FLOWS'));
   });
 });

--- a/test/records.test.js
+++ b/test/records.test.js
@@ -26,6 +26,17 @@ describe('Records Command Structure', () => {
     assert.ok(names.includes('update'));
     assert.ok(names.includes('delete'));
   });
+
+  it('should define inspect subcommand', async () => {
+    const { recordsCmd } = await import('../src/commands/records.js');
+    const wrap = (fn) => fn;
+    const cmd = recordsCmd(wrap);
+    const subcommands = [];
+    const mockYargs = { command: (c) => { subcommands.push(typeof c === 'string' ? c : c.command); return mockYargs; } };
+    cmd.builder(mockYargs);
+    const names = subcommands.map(s => s.split(' ')[0]);
+    assert.ok(names.includes('inspect'));
+  });
 });
 
 // ─── SDK Helper Function Tests ───


### PR DESCRIPTION
## Feature

Adds `jsn records inspect <table> <identifier>` — a single command to understand what happened to a record and what could affect it.

## What it shows

| Section | Source | Description |
|---------|--------|-------------|
| **History** | `sys_audit` | Field-level changes: who changed what and when |
| **Business Rules** | `sys_script` | Active business rules on the records table |
| **Running Flows** | `sys_flow_context` | Flow Designer flows currently referencing this record |

## Usage

```bash
# By sys_id
jsn records inspect incident 46e18c0fa9fe19810066a0083f76bd56

# By record number
jsn records inspect incident INC0000014

# Styled output (auto-detected in TTY)
jsn records inspect --styled incident INC0000014

# JSON output for scripting
jsn records inspect --quiet incident INC0000014
```

## Implementation

- Identifier resolution handles both 32-char hex sys_id and record numbers (queries table by `number` field)
- All three data sources fetched in parallel via `Promise.all`
- Flow Designer failures caught gracefully (returns empty array)
- Styled output with section separators
- 174 tests, all passing

Closes #52