### PR TITLE
feat: enable CRUD for 4 existing dev commands, add 10 new dev commands

### DIFF
--- a/src/commands/dev.js
+++ b/src/commands/dev.js
@@ -6,6 +6,9 @@ import {
   tablesCmd, columnsCmd, importCmd,
   spPagesCmd, spWidgetsCmd, uiPagesCmd, appMenuCmd, scRAPICmd,
   aclsCmd, rolesCmd, propertiesCmd,
+  relationshipsCmd, appmodulesCmd, listcontrolsCmd, viewsCmd,
+  privilegesCmd, securitytypesCmd, uxscriptsCmd, aliasesCmd,
+  catalogscriptsCmd, cataloguipoliciesCmd,
 } from './dev/_simple.js';
 import { flowsCmd } from './dev/flows.js';
 import { formsCmd } from './dev/forms.js';
@@ -44,6 +47,16 @@ export function devCmd(wrap) {
         .command(updateSetsCmd(wrap))
         .command(scopesCmd(wrap))
         .command(propertiesCmd(wrap))
+        .command(relationshipsCmd(wrap))
+        .command(appmodulesCmd(wrap))
+        .command(listcontrolsCmd(wrap))
+        .command(viewsCmd(wrap))
+        .command(privilegesCmd(wrap))
+        .command(securitytypesCmd(wrap))
+        .command(uxscriptsCmd(wrap))
+        .command(aliasesCmd(wrap))
+        .command(catalogscriptsCmd(wrap))
+        .command(cataloguipoliciesCmd(wrap))
         .command(logsCmd(wrap))
         .command(evalCmd(wrap))
         .command(restCmd(wrap));

--- a/src/commands/dev/_simple.js
+++ b/src/commands/dev/_simple.js
@@ -79,11 +79,23 @@ export const columnsCmd = (wrap) => buildDevCmd('columns', 'sys_dictionary', ['c
 export const importCmd = (wrap) => buildDevCmd('import', 'sys_import_set', ['imports', 'imp'], ['sys_import_set', 'sys_import_row', 'sys_target_table', 'sys_target_sys_id'], wrap, { singular: 'import set', readOnly: true });
 export const spPagesCmd = (wrap) => buildDevCmd('sppages', 'sp_page', ['sp-pages', 'pages'], ['id', 'title', 'sys_scope'], wrap, { singular: 'Service Portal page', readOnly: true });
 export const spWidgetsCmd = (wrap) => buildDevCmd('spwidgets', 'sp_widget', ['sp-widget', 'widgets'], ['id', 'name', 'sys_scope'], wrap, { singular: 'Service Portal widget', readOnly: true });
-export const uiPagesCmd = (wrap) => buildDevCmd('uipages', 'sys_ui_page', ['ui-page', 'pages'], ['name', 'sys_scope'], wrap, { singular: 'UI page', readOnly: true });
-export const appMenuCmd = (wrap) => buildDevCmd('appmenu', 'sys_app_application', ['app-menu', 'menu'], ['name', 'active', 'sys_scope'], wrap, { singular: 'application menu', readOnly: true });
+export const uiPagesCmd = (wrap) => buildDevCmd('uipages', 'sys_ui_page', ['ui-page', 'pages'], ['name', 'sys_scope'], wrap, { singular: 'UI page', scopeValidation: true });
+export const appMenuCmd = (wrap) => buildDevCmd('appmenu', 'sys_app_application', ['app-menu', 'menu'], ['name', 'active', 'sys_scope'], wrap, { singular: 'application menu', scopeValidation: true });
 export const scRAPICmd = (wrap) => buildDevCmd('scrapi', 'sys_ws_operation', ['scripted-rest', 'rest-api'], ['name', 'sys_ws_definition', 'sys_scope'], wrap, { singular: 'scripted REST API', readOnly: true });
 
 // Commands with full CRUD
-export const aclsCmd = (wrap) => buildDevCmd('acls', 'sys_security_acl', ['acl'], ['name', 'operation', 'type', 'active', 'sys_scope'], wrap, { singular: 'ACL', readOnly: true });
+export const aclsCmd = (wrap) => buildDevCmd('acls', 'sys_security_acl', ['acl'], ['name', 'operation', 'type', 'active', 'sys_scope'], wrap, { singular: 'ACL', scopeValidation: true });
 export const rolesCmd = (wrap) => buildDevCmd('roles', 'sys_user_role', ['role', 'r'], ['name', 'description', 'elevated_privilege', 'sys_scope'], wrap, { singular: 'role', scopeValidation: true });
-export const propertiesCmd = (wrap) => buildDevCmd('properties', 'sys_properties', ['property', 'prop'], ['name', 'value', 'description', 'sys_scope'], wrap, { singular: 'property', readOnly: true });
+export const propertiesCmd = (wrap) => buildDevCmd('properties', 'sys_properties', ['property', 'prop'], ['name', 'value', 'description', 'sys_scope'], wrap, { singular: 'property', scopeValidation: true });
+
+// New commands for scoped-app tables
+export const relationshipsCmd = (wrap) => buildDevCmd('relationships', 'sys_relationship', ['relationship', 'rel'], ['name', 'sys_scope'], wrap, { singular: 'relationship', scopeValidation: true });
+export const appmodulesCmd = (wrap) => buildDevCmd('appmodules', 'sys_app_module', ['appmodule', 'am'], ['name', 'active', 'sys_scope'], wrap, { singular: 'application module', scopeValidation: true });
+export const listcontrolsCmd = (wrap) => buildDevCmd('listcontrols', 'sys_ui_list_control', ['listcontrol', 'lc'], ['name', 'active', 'sys_scope'], wrap, { singular: 'list control', scopeValidation: true });
+export const viewsCmd = (wrap) => buildDevCmd('views', 'sys_ui_view', ['view', 'vw'], ['name', 'title', 'sys_scope'], wrap, { singular: 'view', scopeValidation: true });
+export const privilegesCmd = (wrap) => buildDevCmd('privileges', 'sys_scope_privilege', ['privilege', 'priv'], ['name', 'status', 'sys_scope'], wrap, { singular: 'privilege', scopeValidation: true });
+export const securitytypesCmd = (wrap) => buildDevCmd('securitytypes', 'sys_security_type', ['securitytype', 'st'], ['name', 'active', 'sys_scope'], wrap, { singular: 'security type', scopeValidation: true });
+export const uxscriptsCmd = (wrap) => buildDevCmd('uxscripts', 'sys_ux_lib_source_script', ['uxscript', 'ux'], ['name', 'active', 'sys_scope'], wrap, { singular: 'UX script', scopeValidation: true });
+export const aliasesCmd = (wrap) => buildDevCmd('aliases', 'sys_alias', ['alias', 'als'], ['name', 'table', 'sys_scope'], wrap, { singular: 'alias', scopeValidation: true });
+export const catalogscriptsCmd = (wrap) => buildDevCmd('catalogscripts', 'catalog_script_client', ['catalogscript', 'cs'], ['name', 'table', 'active', 'sys_scope'], wrap, { singular: 'catalog script', scopeValidation: true });
+export const cataloguipoliciesCmd = (wrap) => buildDevCmd('cataloguipolicies', 'catalog_ui_policy', ['cataloguipolicy', 'cup'], ['short_description', 'table', 'active', 'sys_scope'], wrap, { singular: 'catalog UI policy', scopeValidation: true });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -328,3 +328,52 @@ describe('Integration - Eval', { skip: !INTEGRATION_ENABLED }, () => {
     assert.ok(result.length > 0, 'Should contain log text');
   });
 });
+
+// ─── Scoped-App Dev Commands (PR #110) ───
+
+describe('Integration - Scoped App Commands', { skip: !INTEGRATION_ENABLED }, () => {
+  it('should list views', async () => {
+    const params = new URLSearchParams();
+    params.set('sysparm_limit', '3');
+    params.set('sysparm_fields', 'name,title');
+    params.set('sysparm_display_value', 'all');
+    const records = await app.sdk.list('sys_ui_view', params);
+    assert.ok(Array.isArray(records), 'Should return an array');
+  });
+
+  it('should list aliases', async () => {
+    const params = new URLSearchParams();
+    params.set('sysparm_limit', '3');
+    params.set('sysparm_fields', 'name,table');
+    params.set('sysparm_display_value', 'all');
+    const records = await app.sdk.list('sys_alias', params);
+    assert.ok(Array.isArray(records), 'Should return an array');
+  });
+
+  it('should list privileges', async () => {
+    const params = new URLSearchParams();
+    params.set('sysparm_limit', '3');
+    params.set('sysparm_fields', 'name,status');
+    params.set('sysparm_display_value', 'all');
+    const records = await app.sdk.list('sys_scope_privilege', params);
+    assert.ok(Array.isArray(records), 'Should return an array');
+  });
+
+  it('should list application modules', async () => {
+    const params = new URLSearchParams();
+    params.set('sysparm_limit', '3');
+    params.set('sysparm_fields', 'name,active');
+    params.set('sysparm_display_value', 'all');
+    const records = await app.sdk.list('sys_app_module', params);
+    assert.ok(Array.isArray(records), 'Should return an array');
+  });
+
+  it('should list catalog UI policies', async () => {
+    const params = new URLSearchParams();
+    params.set('sysparm_limit', '3');
+    params.set('sysparm_fields', 'short_description,table');
+    params.set('sysparm_display_value', 'all');
+    const records = await app.sdk.list('catalog_ui_policy', params);
+    assert.ok(Array.isArray(records), 'Should return an array');
+  });
+});


### PR DESCRIPTION
## Summary

Enables create/update/delete on 4 previously read-only dev commands and adds 10 new dev commands for scoped-app development tables.

## Quick wins (removed readOnly flag)

These commands already existed but were read-only. Now they support the full CRUD lifecycle:

| Command | Table | Previously | Now |
|---------|-------|------------|-----|
| `jsn dev acls` | sys_security_acl | readOnly | ✅ create, update, delete |
| `jsn dev properties` | sys_properties | readOnly | ✅ create, update, delete |
| `jsn dev uipages` | sys_ui_page | readOnly | ✅ create, update, delete |
| `jsn dev appmenu` | sys_app_application | readOnly | ✅ create, update, delete |

## New commands (buildDevCmd pattern)

| Command | Table |
|---------|-------|
| `jsn dev relationships` | sys_relationship |
| `jsn dev appmodules` | sys_app_module |
| `jsn dev listcontrols` | sys_ui_list_control |
| `jsn dev views` | sys_ui_view |
| `jsn dev privileges` | sys_scope_privilege |
| `jsn dev securitytypes` | sys_security_type |
| `jsn dev uxscripts` | sys_ux_lib_source_script |
| `jsn dev aliases` | sys_alias |
| `jsn dev catalogscripts` | catalog_script_client |
| `jsn dev cataloguipolicies` | catalog_ui_policy |

All new commands use the standard buildDevCmd pattern with scope validation, supporting list/show/create/update/delete.

Closes #36