### PR TITLE
fix: handle UTF-8 BOM in --data-file and fix scope-check comparison

### DIFF
--- a/src/commands/dev/_generic.js
+++ b/src/commands/dev/_generic.js
@@ -54,6 +54,28 @@ async function checkScope(sdk, recordScope) {
   return { currentScope, recordScope };
 }
 
+/**
+ * Resolve the API scope name from a record's sys_scope reference field.
+ * With sysparm_display_value=all, sys_scope is { display_value: "Name", value: "<sys_id>" }.
+ * getStringField returns the display_value (human-readable), but we need the API name
+ * (e.g. "x_example_app") to compare against getCurrentScope().
+ */
+async function resolveRecordScope(sdk, record) {
+  const sysScope = record['sys_scope'];
+  let scopeId;
+  if (sysScope && typeof sysScope === 'object' && sysScope.value) {
+    scopeId = sysScope.value;
+  } else {
+    return getStringField(record, 'sys_scope');
+  }
+  try {
+    const scopeRecord = await sdk.get('sys_scope', scopeId);
+    return scopeRecord?.scope || 'global';
+  } catch {
+    return getStringField(record, 'sys_scope');
+  }
+}
+
 export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {}) {
   const showFields = opts.showFields !== undefined ? opts.showFields : null;
   const singular = toSingular(name, opts.singular);
@@ -257,7 +279,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
               throw new Error(`${singular} not found: ${id}`);
             }
             const sysID = getStringField(records[0], 'sys_id');
-            const recordScope = getStringField(records[0], 'sys_scope');
+            const recordScope = await resolveRecordScope(app.sdk, records[0]);
 
             if (scopeValidation) {
               const scopeErr = await checkScope(app.sdk, recordScope);
@@ -288,7 +310,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
             }
             const sysID = getStringField(records[0], 'sys_id');
             const recordName = getStringField(records[0], 'name') || id;
-            const recordScope = getStringField(records[0], 'sys_scope');
+            const recordScope = await resolveRecordScope(app.sdk, records[0]);
 
             if (scopeValidation) {
               const scopeErr = await checkScope(app.sdk, recordScope);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -143,6 +143,8 @@ export function parseDataArg(argv) {
   let raw;
   if (argv['data-file']) {
     raw = fs.readFileSync(argv['data-file'], 'utf-8');
+    // Strip UTF-8 BOM (\ufeff) which some editors (Windows/PowerShell) add
+    if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
   } else if (argv.data) {
     raw = argv.data;
   } else {


### PR DESCRIPTION
## Root cause analysis & fix

I confirmed both bugs in the code and have fixes ready for PR.

### Bug 1: BOM parsing failure

**Root cause:** `parseDataArg()` in `src/helpers.js` reads `--data-file` contents via `fs.readFileSync(..., "utf-8")` and passes the raw string to `JSON.parse()`. UTF-8 BOM (`\uFEFF`) is not stripped by Node.js `utf-8` encoding, so files saved with BOM (common on Windows PowerShell) fail with "Unexpected token ... is not valid JSON".

**Fix:** Strip `\uFEFF` before parsing. Node.js's `String.prototype` doesn't auto-strip BOM, so an explicit `.charCodeAt(0) === 0xFEFF` check + `.slice(1)` handles it. Minimal, zero-dependency change.

### Bug 2: Scope-check mismatch

**Root cause:** Two problems in `src/commands/dev/_generic.js`:

1. **Wrong field value for comparison** — `getStringField(record, "sys_scope")` is used to extract the record's scope. With `sysparm_display_value=all`, reference fields return `{ display_value: "Example App", value: "<sys_id>" }`. `getStringField()` prefers `display_value`, returning the human-readable name. But `getCurrentScope()` resolves the current scope from `sys_scope.scope`, which is the **API name** (e.g. `x_example_app`). So the comparison `currentScope === recordScope` always fails even when they're the same scope.

2. **Error message suggests an unresolvable scope** — The error tells you to run `jsn dev scopes set Example App`, but `scopes set` only searches `sys_scope` by `scope=` (API name), not by `name=` (display name). So the recommended fix can't actually be followed.

**Fix:** Added `resolveRecordScope(sdk, record)` helper that extracts the sys_id from `sys_scope.value`, calls `sdk.get("sys_scope", sysId)` to get the actual API name (`scope` field), and falls back to the display name if resolution fails. Both the `update` and `delete` handlers now use this, so the comparison compares API name vs API name correctly, and the error message suggests a scope value that `scopes set` can actually find.
