### PR TITLE
chore: bump 3.0.2 → 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "2.0.3",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jacebenson/jsn",
-      "version": "2.0.3",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump for the BOM and scope-check fixes in PR #112.