### PR TITLE
feat(flows): render full flow structure via ProcessFlow API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.1.5",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jacebenson/jsn",
-      "version": "3.1.5",
-      "hasInstallScript": true,
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",

--- a/src/commands/dev/flows.js
+++ b/src/commands/dev/flows.js
@@ -109,9 +109,9 @@ export function flowsCmd(wrap) {
       console.log('');
       console.log('Run "jsn flows <command> --help" for details.');
       console.log('');
-      console.log('Note: Flow inspection detail varies. V2 flows (with payload)');
-      console.log('show full action inputs and conditions. Subflows and V1 flows');
-      console.log('show step names only.');
+      console.log('Note: Flow structure comes from the ProcessFlow API (the Flow');
+      console.log('Designer UI source), so V1, V2, and subflow definitions all');
+      console.log('render with full action inputs and conditions.');
     },
   };
 }
@@ -187,10 +187,12 @@ function formatFlowInspection(inspection, instanceURL) {
   lines.push('─'.repeat(50));
   const structureLines = formatFlowStructure(inspection);
   lines.push(...structureLines);
-  // Note limitation for V1/subflows without payload detail
-  if (!inspection.payload || Object.keys(inspection.payload).length === 0) {
+  // Note limitation only when we couldn't reconstruct detail from the payload OR the gzip fallback
+  const hasPayload = inspection.payload && Object.keys(inspection.payload).length > 0;
+  const hasDecodedLogic = (inspection.flowLogicInstances || []).some(l => l._decodedValues);
+  if (!hasPayload && !hasDecodedLogic) {
     lines.push('');
-    lines.push('  (step detail limited — this flow lacks a V2 payload)');
+    lines.push('  (step detail limited — no flow definition data available)');
   }
 
   lines.push('');
@@ -351,7 +353,7 @@ function formatFlowStructureFallback(inspection) {
         getStringField(action, 'display_text'),
         'Action',
       );
-      steps.push({ order: parseOrderField(action), text: name });
+      steps.push({ order: parseOrderField(action), text: name, comment: getStringField(action, 'comment') });
     }
   }
 
@@ -363,7 +365,12 @@ function formatFlowStructureFallback(inspection) {
         getStringField(logic, 'display_text'),
         'Logic',
       );
-      steps.push({ order: parseOrderField(logic), text: name });
+      steps.push({
+        order: parseOrderField(logic),
+        text: name,
+        comment: getStringField(logic, 'comment'),
+        decoded: logic._decodedValues || null,
+      });
     }
   }
 
@@ -385,7 +392,57 @@ function formatFlowStructureFallback(inspection) {
     return ['  (no steps found)'];
   }
 
-  return steps.map((step, i) => `${i + 1}. ${step.text}`);
+  const lines = [];
+  steps.forEach((step, i) => {
+    const num = `${i + 1}.`;
+    // Decoded gzip values carry the same input detail as a V2 payload
+    if (step.decoded && (step.text === 'If' || step.text === 'Else If')) {
+      let condition = '';
+      let conditionLabel = '';
+      if (Array.isArray(step.decoded.inputs)) {
+        for (const raw of step.decoded.inputs) {
+          if (!raw || typeof raw !== 'object') continue;
+          const inputName = getStringField(raw, 'name');
+          if (inputName === 'condition') {
+            condition = firstNonEmpty(getStringField(raw, 'displayValue'), getStringField(raw, 'value'));
+          }
+          if (inputName === 'condition_name') {
+            conditionLabel = firstNonEmpty(getStringField(raw, 'displayValue'), getStringField(raw, 'value'));
+          }
+        }
+      }
+      let displayText = step.text;
+      if (conditionLabel) {
+        displayText = `${step.text}: ${conditionLabel}`;
+      } else if (condition && condition.length < 60) {
+        displayText = `${step.text}: ${condition}`;
+      }
+      lines.push(`  ${num} ${displayText}`);
+      if (condition && condition.length >= 60 && !conditionLabel) {
+        lines.push(`     Condition: ${condition}`);
+      }
+    } else if (step.decoded && step.text === 'Set Flow Variables') {
+      lines.push(`  ${num} ${step.text}`);
+      const vars = step.decoded.variables || step.decoded.flowVariables;
+      if (Array.isArray(vars) && vars.length > 0) {
+        lines.push(`     Variables Set:`);
+        for (const raw of vars) {
+          if (!raw || typeof raw !== 'object') continue;
+          const varName = getStringField(raw, 'name');
+          const varValue = firstNonEmpty(getStringField(raw, 'displayValue'), getStringField(raw, 'value'));
+          if (!varName) continue;
+          lines.push(varValue ? `       • ${varName} = ${varValue}` : `       • ${varName}`);
+        }
+      }
+    } else {
+      lines.push(`  ${num} ${step.text}`);
+    }
+    if (step.comment) {
+      lines.push(`     Annotation: ${step.comment}`);
+    }
+  });
+
+  return lines;
 }
 
 function formatStepLine(stepNum, pad, step) {
@@ -425,8 +482,9 @@ function formatActionStep(stepNum, pad, action) {
     }
   }
 
+  const showsTableSuffix = tableName && (actionName === 'Update Record' || actionName === 'Create or Update Record');
   let actionDisplay = actionName;
-  if (tableName && actionName === 'Update Record') {
+  if (showsTableSuffix) {
     actionDisplay = actionName + ' - ' + tableName;
   }
 
@@ -441,7 +499,7 @@ function formatActionStep(stepNum, pad, action) {
     for (const raw of action.inputs) {
       if (!raw || typeof raw !== 'object') continue;
       const inputName = getStringField(raw, 'name');
-      if (inputName === 'table_name') continue;
+      if (inputName === 'table_name' && showsTableSuffix) continue;
 
       let inputValue = firstNonEmpty(getStringField(raw, 'displayValue'), getStringField(raw, 'value'));
       if (!inputValue) continue;
@@ -479,7 +537,7 @@ function formatSubFlowStep(stepNum, pad, subFlow) {
     lines.push(`${pad}${stepNum}. ↪ ${subFlowName}`);
   }
 
-  lines.push(`${pad}   jsn flows "${subFlowName}"`);
+  lines.push(`${pad}   jsn flows show "${subFlowName}"`);
   return lines;
 }
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1,5 +1,6 @@
 // ServiceNow REST API client
 
+import { gunzipSync } from 'node:zlib';
 import { errAuth, errAPI, errNetwork } from './errors.js';
 import { getStringField } from './helpers.js';
 
@@ -246,28 +247,51 @@ export class SDKClient {
       flowOutputs: [],
     };
 
-    // 2) Fetch latest flow version
-    const versionQuery = new URLSearchParams();
-    versionQuery.set('sysparm_display_value', 'all');
-    versionQuery.set('sysparm_limit', '1');
-    versionQuery.set('sysparm_query', `flow=${flowSysID}^ORDERBYDESCsys_updated_on`);
-    versionQuery.set('sysparm_fields', 'sys_id,flow,version,payload,sys_updated_on');
-
-    const versionRecords = await this.list('sys_hub_flow_version', versionQuery);
-    if (versionRecords && versionRecords.length > 0) {
-      inspection.version = versionRecords[0];
-      if (!inspection.flow.version) {
-        inspection.flow.version = getStringField(versionRecords[0], 'version');
+    // 2) Prefer the ProcessFlow API — the Flow Designer UI's own source.
+    //    Returns complete structure for both V2 and legacy V1 flows (the
+    //    version payload field is empty for V1 flows).
+    let payloadLoaded = false;
+    try {
+      const pfResponse = await this.request(`${this.baseURL}/api/now/processflow/flow/${flowSysID}`, { method: 'GET' });
+      const pfData = pfResponse?.result?.data;
+      if (pfData && typeof pfData === 'object' && !pfResponse?.result?.errorMessage) {
+        inspection.payload = pfData;
+        if (!inspection.flow.version) {
+          const pfVersion = getStringField(pfData, 'version');
+          if (pfVersion) inspection.flow.version = pfVersion;
+        }
+        hydrateFlowBlocks(inspection.payload);
+        extractPayloadData(inspection, inspection.payload);
+        payloadLoaded = true;
       }
+    } catch {
+      // ProcessFlow API may not exist on older instances — fall through
+    }
 
-      const payload = getStringField(versionRecords[0], 'payload');
-      if (payload) {
-        try {
-          const payloadData = JSON.parse(payload);
-          inspection.payload = payloadData;
-          extractPayloadData(inspection, payloadData);
-        } catch {
-          // ignore parse error
+    // 2b) Fallback: latest flow version payload
+    if (!payloadLoaded) {
+      const versionQuery = new URLSearchParams();
+      versionQuery.set('sysparm_display_value', 'all');
+      versionQuery.set('sysparm_limit', '1');
+      versionQuery.set('sysparm_query', `flow=${flowSysID}^ORDERBYDESCsys_updated_on`);
+      versionQuery.set('sysparm_fields', 'sys_id,flow,version,payload,sys_updated_on');
+
+      const versionRecords = await this.list('sys_hub_flow_version', versionQuery);
+      if (versionRecords && versionRecords.length > 0) {
+        inspection.version = versionRecords[0];
+        if (!inspection.flow.version) {
+          inspection.flow.version = getStringField(versionRecords[0], 'version');
+        }
+
+        const payload = getStringField(versionRecords[0], 'payload');
+        if (payload) {
+          try {
+            const payloadData = JSON.parse(payload);
+            inspection.payload = payloadData;
+            extractPayloadData(inspection, payloadData);
+          } catch {
+            // ignore parse error
+          }
         }
       }
     }
@@ -295,15 +319,24 @@ export class SDKClient {
     }
 
     if (!inspection.flowLogicInstances || inspection.flowLogicInstances.length === 0) {
-      const logicTables = ['sys_hub_flow_logic', 'sys_hub_flow_logic_instance_v2'];
-      for (const table of logicTables) {
+      const logicTables = [
+        { table: 'sys_hub_flow_logic', payloadField: 'inputs' },
+        { table: 'sys_hub_flow_logic_instance_v2', payloadField: 'values' },
+      ];
+      for (const { table, payloadField } of logicTables) {
         const logicQuery = new URLSearchParams();
         logicQuery.set('sysparm_display_value', 'all');
         logicQuery.set('sysparm_query', `flow=${flowSysID}^ORDERBYorder`);
-        logicQuery.set('sysparm_fields', 'sys_id,order,name,display_text,comment,parent_ui_id,logic_definition');
+        logicQuery.set('sysparm_fields', `sys_id,order,name,display_text,comment,parent_ui_id,logic_definition,${payloadField}`);
         logicQuery.set('sysparm_limit', '200');
         const records = await this.list(table, logicQuery);
-        if (records) inspection.flowLogicInstances.push(...records);
+        if (records) {
+          for (const rec of records) {
+            const decoded = decodeGzipJson(rec[payloadField]);
+            if (decoded) rec._decodedValues = decoded;
+          }
+          inspection.flowLogicInstances.push(...records);
+        }
       }
       inspection.flowLogicInstances.sort((a, b) => parseOrderField(a) - parseOrderField(b));
     }
@@ -634,8 +667,72 @@ function toMapSlice(v) {
   return v.filter(item => item && typeof item === 'object');
 }
 
+/**
+ * The ProcessFlow API returns flow structure as flat arrays where children
+ * reference their parent logic step via a `parent` / `parent_ui_id` field
+ * (a uiUniqueIdentifier value). The payload-based renderer expects nested
+ * `flowBlock` arrays on each logic instance. Rebuild that nesting here so
+ * both data sources render identically.
+ */
+export function hydrateFlowBlocks(payload) {
+  const blockKeys = ['actionInstances', 'flowLogicInstances', 'subFlowInstances'];
+  const items = [];
+  for (const key of blockKeys) {
+    if (Array.isArray(payload[key])) {
+      for (const item of payload[key]) {
+        if (item && typeof item === 'object') items.push(item);
+      }
+    }
+  }
+  if (items.length === 0) return;
+
+  // If the payload already has nested flowBlock arrays (version-payload
+  // shape), leave it alone.
+  const logicItems = Array.isArray(payload.flowLogicInstances) ? payload.flowLogicInstances : [];
+  if (logicItems.some(l => l && typeof l === 'object' && Array.isArray(l.flowBlock))) return;
+
+  // Build parent → children map keyed by uiUniqueIdentifier
+  const childrenByParent = new Map();
+  for (const item of items) {
+    const parentId = getStringField(item, 'parent_ui_id') || getStringField(item, 'parent');
+    if (!parentId) continue;
+    if (!childrenByParent.has(parentId)) childrenByParent.set(parentId, []);
+    childrenByParent.get(parentId).push(item);
+  }
+
+  // Attach sorted flowBlock to each logic instance
+  for (const logic of logicItems) {
+    if (!logic || typeof logic !== 'object') continue;
+    const uid = getStringField(logic, 'uiUniqueIdentifier');
+    const children = uid ? childrenByParent.get(uid) : null;
+    if (Array.isArray(children) && children.length > 0) {
+      children.sort((a, b) => parseOrderField(a) - parseOrderField(b));
+      logic.flowBlock = children;
+    }
+  }
+}
+
 function parseOrderField(record) {
   const order = getStringField(record, 'order');
   const n = parseInt(order, 10);
   return isNaN(n) ? 0 : n;
+}
+
+/**
+ * Decode a ServiceNow flow-logic "values" field: base64-gzip JSON.
+ * Returns the parsed object, or null when the field is empty / not gzip / unparseable.
+ */
+export function decodeGzipJson(value) {
+  if (!value) return null;
+  const s = (typeof value === 'object' && value !== null)
+    ? (value.value ?? value.display_value ?? '')
+    : String(value);
+  const trimmed = s.trim();
+  if (!trimmed.startsWith('H4sI')) return null; // not gzip base64
+  try {
+    const decoded = gunzipSync(Buffer.from(trimmed, 'base64')).toString('utf-8');
+    return JSON.parse(decoded);
+  } catch {
+    return null;
+  }
 }

--- a/test/sdk-flows.test.js
+++ b/test/sdk-flows.test.js
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { gzipSync } from 'node:zlib';
+import { decodeGzipJson, hydrateFlowBlocks } from '../src/sdk.js';
+
+function gzipB64(obj) {
+  return gzipSync(Buffer.from(JSON.stringify(obj), 'utf-8')).toString('base64');
+}
+
+test('decodeGzipJson decodes base64-gzip JSON with surrounding whitespace', () => {
+  const payload = { inputs: [{ name: 'condition', value: '{{x}}ISNOTEMPTY' }], variables: [] };
+  const raw = `\n\t\t\t${gzipB64(payload)}`;
+  const result = decodeGzipJson(raw);
+  assert.deepEqual(result, payload);
+});
+
+test('decodeGzipJson handles display_value/value object form', () => {
+  const payload = { inputs: [] };
+  const result = decodeGzipJson({ display_value: gzipB64(payload), value: gzipB64(payload) });
+  assert.deepEqual(result, payload);
+});
+
+test('decodeGzipJson returns null for empty input', () => {
+  assert.equal(decodeGzipJson(''), null);
+  assert.equal(decodeGzipJson(null), null);
+  assert.equal(decodeGzipJson(undefined), null);
+  assert.equal(decodeGzipJson('   '), null);
+});
+
+test('decodeGzipJson returns null for non-gzip strings', () => {
+  assert.equal(decodeGzipJson('plain json {"a":1}'), null);
+  assert.equal(decodeGzipJson('H4sI not-valid-base64'), null);
+});
+
+test('decodeGzipJson returns null for corrupt gzip', () => {
+  assert.equal(decodeGzipJson('H4sIAAAAAAAA/w=='), null);
+});
+
+test('hydrateFlowBlocks builds flowBlock nesting from flat parent links', () => {
+  const payload = {
+    flowLogicInstances: [
+      { uiUniqueIdentifier: 'if-1', flowLogicDefinition: { name: 'If' }, order: '1' },
+      { uiUniqueIdentifier: 'if-2', flowLogicDefinition: { name: 'If' }, order: '3', parent: 'if-1' },
+    ],
+    actionInstances: [
+      { name: 'Update Record', order: '2', parent: 'if-1' },
+      { name: 'Log', order: '4', parent: 'if-2' },
+    ],
+  };
+  hydrateFlowBlocks(payload);
+  const if1 = payload.flowLogicInstances[0];
+  const if2 = payload.flowLogicInstances[1];
+  assert.ok(Array.isArray(if1.flowBlock), 'If-1 should have a flowBlock');
+  assert.equal(if1.flowBlock.length, 2, 'If-1 should contain action + nested If');
+  assert.deepEqual(if1.flowBlock.map(x => x.name ?? x.uiUniqueIdentifier), ['Update Record', 'if-2']);
+  assert.ok(Array.isArray(if2.flowBlock), 'If-2 should have a flowBlock');
+  assert.deepEqual(if2.flowBlock.map(x => x.name), ['Log']);
+});
+
+test('hydrateFlowBlocks leaves existing flowBlock arrays alone (version-payload shape)', () => {
+  const payload = {
+    flowLogicInstances: [
+      { uiUniqueIdentifier: 'if-1', flowLogicDefinition: { name: 'If' }, flowBlock: [{ name: 'Update Record' }] },
+    ],
+    actionInstances: [{ name: 'Update Record', parent: 'if-1' }],
+  };
+  hydrateFlowBlocks(payload);
+  assert.deepEqual(payload.flowLogicInstances[0].flowBlock.map(x => x.name), ['Update Record']);
+});
+
+test('hydrateFlowBlocks handles empty input', () => {
+  const payload = {};
+  hydrateFlowBlocks(payload);
+  assert.deepEqual(payload, {});
+});


### PR DESCRIPTION
Use the Flow Designer UI's own data source (/api/now/processflow/flow) as the primary source for flow inspection. It returns complete structure for V2, V1, and subflow definitions alike — the sys_hub_flow_version payload field is empty for legacy V1 flows, which previously limited those flows to step names only.

- inspectFlow: ProcessFlow API first, version payload fallback, table fallback last (with base64-gzip decode of logic values)
- hydrateFlowBlocks: rebuild nested flowBlock from flat parent links so ProcessFlow data renders with the existing payload renderer
- Render 'Create or Update Record' with its table pill (was skipped)
- Subflow hint uses 'jsn flows show' (was broken: 'jsn flows')
- Update stale help/limitation text; add decodeGzipJson + hydration tests

## Description
<!-- Describe your changes -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Checklist

### Architecture Pattern (Important!)
When adding new commands that query ServiceNow tables:
- [ ] I defined local types in the command file (not in SDK)
- [ ] I used `app.SDK.List()` directly with inline query logic
- [ ] I did NOT add domain-specific helper methods to `internal/sdk/`

**Pattern to follow:** See `internal/commands/dev/forms.go` - local types, direct `app.SDK.List()` calls, inline query building with `url.Values{}`.

**Anti-pattern to avoid:** Don't create SDK methods like `ListFormViews()`, `GetSPPage()`, etc. Keep the SDK lean with only core HTTP operations.

### General
- [ ] Tests pass (`go test ./...`)
- [ ] Code follows project style
- [ ] Changes are documented

## Testing
<!-- How did you test these changes? -->

## Related Issues
<!-- Link to related issues -->
