### PR TITLE
feat(flows): expand nested subflows with --depth flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jacebenson/jsn",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {

--- a/src/commands/dev/flows.js
+++ b/src/commands/dev/flows.js
@@ -14,7 +14,12 @@ export function flowsCmd(wrap) {
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
             .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
-            .option('limit', { alias: 'l', type: 'number', default: 50, describe: 'Max records' }),
+            .option('limit', { alias: 'l', type: 'number', default: 50, describe: 'Max records' })
+            .option('depth', {
+              type: 'number',
+              default: 2,
+              describe: 'Expand nested subflows to this depth (1 = subflow names only, 2 = one level, 3+ = deeper)',
+            }),
           handler: wrap(async (argv, app) => {
             app.requireInstance();
             const columns = argv.columns ? argv.columns.split(',') : ['name', 'active', 'description', 'sys_created_by', 'sys_updated_on'];
@@ -28,7 +33,13 @@ export function flowsCmd(wrap) {
             if (picked === undefined) return; // user cancelled
             if (picked) {
               const inspection = await app.sdk.inspectFlow(getStringField(picked, 'sys_id'));
-              const formatted = formatFlowInspection(inspection, app.getEffectiveInstance());
+              const ctx = {
+                sdk: app.sdk,
+                instanceURL: app.getEffectiveInstance(),
+                depth: Math.max(1, Math.floor(argv.depth ?? 2)),
+                visited: new Set([inspection.flow.sysID]),
+              };
+              const formatted = await formatFlowInspection(inspection, ctx);
               return app.ok({ ...inspection, _formatted: formatted }, {
                 summary: `Flow: ${inspection.flow.name}`,
                 breadcrumbs: [{ action: 'list', cmd: 'jsn flows list', description: 'Back to all flows' }],
@@ -56,9 +67,21 @@ export function flowsCmd(wrap) {
           command: 'show <identifier>',
           aliases: ['get'],
           describe: 'Show flow details by name or sys_id',
+          builder: (y) => y
+            .option('depth', {
+              type: 'number',
+              default: 2,
+              describe: 'Expand nested subflows to this depth (1 = subflow names only, 2 = one level, 3+ = deeper)',
+            }),
           handler: wrap(async (argv, app) => {
             const inspection = await app.sdk.inspectFlow(argv.identifier);
-            const formatted = formatFlowInspection(inspection, app.getEffectiveInstance());
+            const ctx = {
+              sdk: app.sdk,
+              instanceURL: app.getEffectiveInstance(),
+              depth: Math.max(1, Math.floor(argv.depth ?? 2)),
+              visited: new Set([inspection.flow.sysID]),
+            };
+            const formatted = await formatFlowInspection(inspection, ctx);
             const data = { ...inspection, _formatted: formatted };
             app.ok(data, {
               summary: `Flow: ${inspection.flow.name}`,
@@ -116,8 +139,9 @@ export function flowsCmd(wrap) {
   };
 }
 
-function formatFlowInspection(inspection, instanceURL) {
+async function formatFlowInspection(inspection, ctx) {
   const lines = [];
+  const instanceURL = ctx?.instanceURL || '';
   const flow = inspection.flow;
 
   lines.push('');
@@ -185,7 +209,7 @@ function formatFlowInspection(inspection, instanceURL) {
   lines.push('');
   lines.push('⚡ FLOW STRUCTURE');
   lines.push('─'.repeat(50));
-  const structureLines = formatFlowStructure(inspection);
+  const structureLines = await formatFlowStructure(inspection, ctx);
   lines.push(...structureLines);
   // Note limitation only when we couldn't reconstruct detail from the payload OR the gzip fallback
   const hasPayload = inspection.payload && Object.keys(inspection.payload).length > 0;
@@ -256,15 +280,15 @@ function inferFlowVersion(inspection) {
   return 'Unset';
 }
 
-function formatFlowStructure(inspection) {
+async function formatFlowStructure(inspection, ctx) {
   const payload = inspection.payload;
   if (Object.keys(payload).length > 0) {
-    return formatFlowStructureFromPayload(payload);
+    return formatFlowStructureFromPayload(payload, ctx);
   }
   return formatFlowStructureFallback(inspection);
 }
 
-function formatFlowStructureFromPayload(payload) {
+async function formatFlowStructureFromPayload(payload, ctx) {
   const childUIDs = new Set();
 
   function markChildren(items) {
@@ -314,10 +338,10 @@ function formatFlowStructureFromPayload(payload) {
   const lines = [];
   let stepNum = 1;
 
-  function walk(steps, indent) {
+  async function walk(steps, indent) {
     for (const step of steps) {
       const pad = '    '.repeat(indent);
-      lines.push(...formatStepLine(stepNum, pad, step));
+      lines.push(...await formatStepLine(stepNum, pad, step, ctx));
       stepNum++;
 
       if (step.stepType !== 'logic') continue;
@@ -334,11 +358,11 @@ function formatFlowStructureFromPayload(payload) {
         });
       }
       children.sort((a, b) => a.order - b.order);
-      walk(children, indent + 1);
+      await walk(children, indent + 1);
     }
   }
 
-  walk(roots, 0);
+  await walk(roots, 0);
   return lines;
 }
 
@@ -445,12 +469,12 @@ function formatFlowStructureFallback(inspection) {
   return lines;
 }
 
-function formatStepLine(stepNum, pad, step) {
+async function formatStepLine(stepNum, pad, step, ctx) {
   switch (step.stepType) {
     case 'logic':
       return formatLogicStep(stepNum, pad, step.data);
     case 'subflow':
-      return formatSubFlowStep(stepNum, pad, step.data);
+      return formatSubFlowStep(stepNum, pad, step.data, ctx);
     default:
       return formatActionStep(stepNum, pad, step.data);
   }
@@ -519,7 +543,7 @@ function formatActionStep(stepNum, pad, action) {
   return lines;
 }
 
-function formatSubFlowStep(stepNum, pad, subFlow) {
+export async function formatSubFlowStep(stepNum, pad, subFlow, ctx) {
   const lines = [];
   const subFlowName = firstNonEmpty(
     getNestedString(subFlow, 'subFlowType', 'fName'),
@@ -537,7 +561,43 @@ function formatSubFlowStep(stepNum, pad, subFlow) {
     lines.push(`${pad}${stepNum}. ↪ ${subFlowName}`);
   }
 
-  lines.push(`${pad}   jsn flows show "${subFlowName}"`);
+  // Recurse into the subflow when depth allows and we haven't already seen it.
+  // Note: `subflowSysId` on the instance is a snapshot id (sys_hub_flow_snapshot),
+  // NOT the flow id. The embedded `subFlow.parentFlow` is the real flow sys_id.
+  const subflowSysId = firstNonEmpty(
+    getNestedString(subFlow, 'subFlow', 'parentFlow'),
+    getStringField(subFlow, 'subflowSysId'),
+    getNestedString(subFlow, 'subFlow', 'sys_id'),
+    getStringField(subFlow, 'sys_id'),
+  );
+  const depth = ctx?.depth ?? 1;
+  const canRecurse = ctx?.sdk && subflowSysId && depth > 1 && !ctx.visited.has(subflowSysId);
+
+  if (!canRecurse) {
+    if (!subflowSysId) {
+      lines.push(`${pad}   (subflow definition not found)`);
+    } else if (depth <= 1) {
+      lines.push(`${pad}   jsn flows show "${subFlowName}"`);
+    }
+    return lines;
+  }
+
+  ctx.visited.add(subflowSysId);
+  try {
+    const subInspection = await ctx.sdk.inspectFlow(subflowSysId);
+    const subCtx = { ...ctx, depth: depth - 1 };
+    const subLines = await formatFlowStructure(subInspection, subCtx);
+    if (subLines.length === 0) {
+      lines.push(`${pad}   (no steps found)`);
+    } else {
+      const innerPad = pad + '   ';
+      for (const l of subLines) {
+        lines.push(innerPad + l.replace(/^ {2}/, ''));
+      }
+    }
+  } catch (e) {
+    lines.push(`${pad}   (could not load subflow: ${e.message})`);
+  }
   return lines;
 }
 

--- a/test/sdk-flows.test.js
+++ b/test/sdk-flows.test.js
@@ -73,3 +73,59 @@ test('hydrateFlowBlocks handles empty input', () => {
   hydrateFlowBlocks(payload);
   assert.deepEqual(payload, {});
 });
+
+test('formatSubFlowStep resolves parentFlow (real flow id) over subflowSysId (snapshot id)', async () => {
+  const { formatSubFlowStep } = await import('../src/commands/dev/flows.js');
+  const subFlow = {
+    subflowSysId: 'snapshot-123', // snapshot id — should NOT be used
+    subFlow: { parentFlow: 'flow-456', name: 'My Subflow' },
+    name: 'My Subflow',
+  };
+  let resolvedId = null;
+  const ctx = {
+    sdk: { inspectFlow: async (id) => { resolvedId = id; return { flow: { sysID: id }, payload: {} }; } },
+    instanceURL: 'https://x.service-now.com',
+    depth: 2,
+    visited: new Set(['parent-flow']),
+  };
+  const lines = await formatSubFlowStep(1, '', subFlow, ctx);
+  assert.equal(resolvedId, 'flow-456', 'should recurse into subFlow.parentFlow, not subflowSysId');
+  assert.ok(lines[0].includes('My Subflow'), 'first line names the subflow');
+});
+
+test('formatSubFlowStep shows hint at depth 1 instead of recursing', async () => {
+  const { formatSubFlowStep } = await import('../src/commands/dev/flows.js');
+  const subFlow = {
+    subflowSysId: 'snapshot-123',
+    subFlow: { parentFlow: 'flow-456', name: 'My Subflow' },
+    name: 'My Subflow',
+  };
+  let called = false;
+  const ctx = {
+    sdk: { inspectFlow: async () => { called = true; return {}; } },
+    instanceURL: 'https://x.service-now.com',
+    depth: 1,
+    visited: new Set(['parent-flow']),
+  };
+  const lines = await formatSubFlowStep(1, '', subFlow, ctx);
+  assert.equal(called, false, 'should not fetch at depth 1');
+  assert.ok(lines.some(l => l.includes('jsn flows show')), 'should show drill hint');
+});
+
+test('formatSubFlowStep guards against cycles via visited set', async () => {
+  const { formatSubFlowStep } = await import('../src/commands/dev/flows.js');
+  const subFlow = {
+    subflowSysId: 'snapshot-123',
+    subFlow: { parentFlow: 'flow-456', name: 'Loop Subflow' },
+    name: 'Loop Subflow',
+  };
+  let called = false;
+  const ctx = {
+    sdk: { inspectFlow: async () => { called = true; return {}; } },
+    instanceURL: 'https://x.service-now.com',
+    depth: 3,
+    visited: new Set(['flow-456']), // already visited → cycle
+  };
+  await formatSubFlowStep(1, '', subFlow, ctx);
+  assert.equal(called, false, 'should not re-fetch an already-visited subflow');
+});


### PR DESCRIPTION
Add recursive subflow expansion to 'jsn flows show' (and the flows list picker). Subflow steps now render their full structure inline instead of a bare name + drill hint.

- --depth N controls recursion: 1 = names only, 2 = one level (default), 3+ = deeper
- Resolves the real flow id from subFlow.parentFlow (subflowSysId on the instance is a snapshot id, not the flow id)
- Visited-set cycle guard prevents infinite recursion
- Fix missing await on recursive walk that corrupted step numbering
- Add formatSubFlowStep unit tests (resolution, depth-1 hint, cycle)
- Bump to 3.4.2

## Description
<!-- Describe your changes -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Checklist

### Architecture Pattern (Important!)
When adding new commands that query ServiceNow tables:
- [ ] I defined local types in the command file (not in SDK)
- [ ] I used `app.SDK.List()` directly with inline query logic
- [ ] I did NOT add domain-specific helper methods to `internal/sdk/`

**Pattern to follow:** See `internal/commands/dev/forms.go` - local types, direct `app.SDK.List()` calls, inline query building with `url.Values{}`.

**Anti-pattern to avoid:** Don't create SDK methods like `ListFormViews()`, `GetSPPage()`, etc. Keep the SDK lean with only core HTTP operations.

### General
- [ ] Tests pass (`go test ./...`)
- [ ] Code follows project style
- [ ] Changes are documented

## Testing
<!-- How did you test these changes? -->

## Related Issues
<!-- Link to related issues -->
