### PR TITLE
fix(docs): swap node:sqlite for better-sqlite3 to fix FTS5 on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.1.5",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jacebenson/jsn",
-      "version": "3.1.5",
-      "hasInstallScript": true,
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
         "@inquirer/prompts": "^7.5.1",
+        "better-sqlite3": "^13.0.3",
         "chalk": "^5.4.1",
         "cli-table3": "^0.6.5",
         "gray-matter": "^4.0.3",
@@ -525,6 +525,18 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -783,6 +795,15 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@inquirer/core": "^10.1.0",
     "@inquirer/prompts": "^7.5.1",
+    "better-sqlite3": "^13.0.3",
     "chalk": "^5.4.1",
     "cli-table3": "^0.6.5",
     "gray-matter": "^4.0.3",

--- a/src/commands/docs/db.js
+++ b/src/commands/docs/db.js
@@ -3,7 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { DatabaseSync } from 'node:sqlite';
+import Database from 'better-sqlite3';
 
 const DOCS_DIR_NAME = 'servicenow-cli/docs';
 
@@ -37,7 +37,7 @@ export function ensureDocsCacheDir() {
 export function openDocsDb(opts = {}) {
   const dbPath = opts.dbPath || getDocsDbPath();
   ensureDocsCacheDir();
-  const db = new DatabaseSync(dbPath);
+  const db = new Database(dbPath);
   db.exec('PRAGMA journal_mode = WAL');
   return db;
 }

--- a/src/commands/docs/search.js
+++ b/src/commands/docs/search.js
@@ -1,7 +1,7 @@
 // CLI search against the docs SQLite database.
 
 import fs from 'node:fs';
-import { DatabaseSync } from 'node:sqlite';
+import Database from 'better-sqlite3';
 import { getDocsDbPath, hasEmbeddings } from './db.js';
 import { encodeText, similarity, bytesToPhases, DEFAULT_DIM } from './hrr.js';
 
@@ -24,7 +24,7 @@ export function searchDocs(opts = {}) {
     throw new Error(`Database not found: ${dbPath}. Run "jsn docs sync" first.`);
   }
 
-  const db = new DatabaseSync(dbPath, { readOnly: true });
+  const db = new Database(dbPath, { readonly: true });
   const limit = Math.min(parseInt(opts.limit, 10) || 20, 1000);
   const offset = parseInt(opts.offset, 10) || 0;
   const bundle = opts.bundle ? String(opts.bundle) : null;

--- a/src/commands/docs/serve.js
+++ b/src/commands/docs/serve.js
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import http from 'node:http';
 import { URL } from 'node:url';
-import { DatabaseSync } from 'node:sqlite';
+import Database from 'better-sqlite3';
 import { getDocsDbPath, hasEmbeddings } from './db.js';
 import { encodeText, similarity, bytesToPhases, DEFAULT_DIM } from './hrr.js';
 
@@ -72,7 +72,7 @@ export function serveDocs(opts = {}) {
     throw new Error(`Database not found: ${dbPath}. Run "jsn docs sync" first.`);
   }
 
-  const db = new DatabaseSync(dbPath, { readOnly: true });
+  const db = new Database(dbPath, { readonly: true });
   const hasEmb = hasEmbeddings(db);
   const hrrDim = (() => {
     try {


### PR DESCRIPTION
## What

`jsn docs sync` fails on Windows (PowerShell) with `no such module: fts5`. The root cause is upstream in Node.js, not jsn:

- `node:sqlite` is compiled with `SQLITE_ENABLE_FTS5` on official **Linux** builds, but **not** on official **Windows** builds (or several Homebrew macOS builds) — e.g. Node v22.14.0 Windows ships SQLite 3.47.2 with `FTS5 enabled: NO` (verified via `PRAGMA compile_options`).
- Node's own feature request to enable FTS5 (nodejs/node#56951) was closed without merging, and the flag only landed later in `sqlite.gyp` via nodejs/node#57621 (v22.16.0+).
- Since the schema does `CREATE VIRTUAL TABLE ... USING fts5(...)`, any build without FTS5 throws and the whole sync dies.

## Fix

Swap `node:sqlite` → **better-sqlite3**, which statically compiles its own SQLite with FTS5 enabled on every platform (verified: SQLite 3.53.4, `ENABLE_FTS5` present). The API is drop-in compatible for the three files that used `DatabaseSync`:

- `src/commands/docs/db.js` — `new Database(dbPath)`
- `src/commands/docs/search.js` — `new Database(dbPath, { readonly: true })`
- `src/commands/docs/serve.js` — `new Database(dbPath, { readonly: true })`

Everything else (named `@params`, `prepare().get/all/run`, `exec`, triggers, WAL) is identical.

## Verification

- `npm test`: **188 pass, 0 fail** (1 skipped = integration test requiring a live sync)
- `npm run lint`: same 24 pre-existing errors as clean `main`, zero new
- End-to-end ingest → search on a small corpus works through the real `ingestDocs` / `searchDocs` code path
- `node bin/jsn.js docs --help` boots clean

## Compatibility

better-sqlite3 requires Node `>=22`; jsn declares `engines.node >=22.5.0`, so no floor change needed.

Fixes #132