### PR TITLE
fix(auth): stop auto-opening browser for OAuth — print URL instead

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -58,24 +58,6 @@ function removePKCEState(instance) {
 const DEFAULT_OAUTH_CLIENT_ID = '543e5655f77746a28228c6009a599dfb';
 const REDIRECT_URI = '/sdk-oauth.do';
 
-// ─── WSL detection ───
-
-/**
- * Detect if running under Windows Subsystem for Linux.
- * Reads /proc/version which contains "Microsoft" or "WSL" on WSL.
- */
-let _cachedIsWSL = null;
-async function isWSLEnv() {
-  if (_cachedIsWSL !== null) return _cachedIsWSL;
-  try {
-    const data = fs.readFileSync('/proc/version', 'utf-8');
-    _cachedIsWSL = /microsoft|wsl/i.test(data);
-  } catch {
-    _cachedIsWSL = false;
-  }
-  return _cachedIsWSL;
-}
-
 // ─── Basic auth from environment variables ───
 // SN_USERNAME / SN_PASSWORD — global credentials
 // SN_<INSTANCE>_USERNAME / SN_<INSTANCE>_PASSWORD — instance-specific (e.g. SN_DEV328604_USERNAME)
@@ -390,43 +372,12 @@ export class AuthManager {
     const authURL = buildAuthURL(instanceURL, clientID, pkce);
 
     console.log();
-    console.log('Opening browser for OAuth authentication...');
-    console.log('If the browser does not open automatically, visit:');
+    console.log('Open this URL in your browser to authenticate:');
     console.log(authURL);
     console.log();
-
-    // Try to open browser
-    const open = (await import('node:child_process')).spawn;
-    const platform = process.platform;
-    let cmd, args;
-    if (platform === 'darwin') {
-      cmd = 'open';
-      args = [authURL];
-    } else if (platform === 'win32') {
-      cmd = 'cmd';
-      // Windows: cmd.exe interprets & as a command separator, which truncates
-      // the URL after the first parameter. Passing an empty string as the first
-      // arg to `start` serves as the window title, and spawn auto-quotes the
-      // URL arg, protecting & and other special chars from cmd.exe's parser.
-      args = ['/c', 'start', '', authURL];
-    } else {
-      // WSL detection: check if we're running under Windows Subsystem for Linux
-      // On WSL, xdg-open delegates to cmd.exe /C start <url>, which truncates
-      // on &. We call cmd.exe directly with proper quoting instead.
-      const isWSL = platform === 'linux' && (await isWSLEnv());
-      if (isWSL) {
-        cmd = 'cmd.exe';
-        args = ['/c', 'start', '', authURL];
-      } else {
-        cmd = 'xdg-open';
-        args = [authURL];
-      }
-    }
-    const child = open(cmd, args, { detached: true, stdio: 'ignore' });
-    child.on('error', () => {
-      // Browser open command not available — user will open the URL manually
-    });
-    child.unref();
+    console.log('(The browser is not opened automatically — if a browser tab opens,');
+    console.log(' use the URL above if the opened page shows an error.)');
+    console.log();
 
     console.log('After authenticating in the browser, copy the authorization code shown on the page.');
     console.log('(input is hidden for security — just paste and press Enter)');


### PR DESCRIPTION
## What

`jsn setup` / `jsn auth login` tried to auto-open the OAuth URL in the browser, but the opened link was unreliable:

- **Windows/WSL:** the URL is passed to `cmd /c start "" <url>` unquoted (libuv only quotes args containing spaces/quotes, so `&` passes raw). cmd.exe splits on `&`, so the browser opened a truncated URL missing `client_id`, `redirect_uri`, `state`, and `code_challenge` — OAuth failed. The code comment claimed spawn "auto-quotes" the arg; it doesn't.
- **Linux:** `xdg-open` delegation varies by desktop environment.

The URL printed in the terminal always worked.

## Fix

Stop auto-opening the browser entirely. Remove the spawn/xdg-open/cmd.exe logic and the WSL detection helper, and print the URL with a clear prompt instead. The user opens exactly the link that works.

## Verification

- `npm test`: **188 pass, 0 fail** (1 skipped = integration)
- No remaining browser-open / WSL refs in `src/auth.js`
- URL still builds correctly (7 `&`-separated params, all present)
- `login()` remains async with the same public shape

Fixes #131