### PR TITLE
feat(flows): full flow rendering — structure, depth, variables, labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jacebenson/jsn",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {

--- a/src/commands/dev/flows.js
+++ b/src/commands/dev/flows.js
@@ -480,7 +480,7 @@ async function formatStepLine(stepNum, pad, step, ctx) {
   }
 }
 
-function formatActionStep(stepNum, pad, action) {
+export function formatActionStep(stepNum, pad, action) {
   const lines = [];
   let actionName = firstNonEmpty(
     getNestedString(action, 'actionType', 'fName'),
@@ -527,16 +527,22 @@ function formatActionStep(stepNum, pad, action) {
 
       let inputValue = firstNonEmpty(getStringField(raw, 'displayValue'), getStringField(raw, 'value'));
       if (!inputValue) continue;
-      if (inputValue.length > 50) {
-        inputValue = inputValue.slice(0, 47) + '...';
-      }
 
       let label = inputName;
       if (raw.parameter && typeof raw.parameter === 'object') {
         label = firstNonEmpty(getStringField(raw.parameter, 'label'), label);
       }
 
-      lines.push(`${pad}    ${label}: ${inputValue}`);
+      // ServiceNow writes multi-field payloads (encoded-query style) as
+      // "field=value^field2=value2". Split those onto one line per field;
+      // plain long strings stay on a single line, untruncated.
+      if (inputValue.includes('^')) {
+        for (const field of inputValue.split('^')) {
+          if (field) lines.push(`${pad}    ${label}: ${field}`);
+        }
+      } else {
+        lines.push(`${pad}    ${label}: ${inputValue}`);
+      }
     }
   }
 

--- a/src/commands/dev/flows.js
+++ b/src/commands/dev/flows.js
@@ -14,7 +14,12 @@ export function flowsCmd(wrap) {
           builder: (y) => y
             .option('query', { type: 'string', describe: 'Encoded query (e.g. "nameLIKEincident" or "active=true")' })
             .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' })
-            .option('limit', { alias: 'l', type: 'number', default: 50, describe: 'Max records' }),
+            .option('limit', { alias: 'l', type: 'number', default: 50, describe: 'Max records' })
+            .option('depth', {
+              type: 'number',
+              default: 2,
+              describe: 'Expand nested subflows to this depth (1 = subflow names only, 2 = one level, 3+ = deeper)',
+            }),
           handler: wrap(async (argv, app) => {
             app.requireInstance();
             const columns = argv.columns ? argv.columns.split(',') : ['name', 'active', 'description', 'sys_created_by', 'sys_updated_on'];
@@ -28,7 +33,13 @@ export function flowsCmd(wrap) {
             if (picked === undefined) return; // user cancelled
             if (picked) {
               const inspection = await app.sdk.inspectFlow(getStringField(picked, 'sys_id'));
-              const formatted = formatFlowInspection(inspection, app.getEffectiveInstance());
+              const ctx = {
+                sdk: app.sdk,
+                instanceURL: app.getEffectiveInstance(),
+                depth: Math.max(1, Math.floor(argv.depth ?? 2)),
+                visited: new Set([inspection.flow.sysID]),
+              };
+              const formatted = await formatFlowInspection(inspection, ctx);
               return app.ok({ ...inspection, _formatted: formatted }, {
                 summary: `Flow: ${inspection.flow.name}`,
                 breadcrumbs: [{ action: 'list', cmd: 'jsn flows list', description: 'Back to all flows' }],
@@ -56,9 +67,21 @@ export function flowsCmd(wrap) {
           command: 'show <identifier>',
           aliases: ['get'],
           describe: 'Show flow details by name or sys_id',
+          builder: (y) => y
+            .option('depth', {
+              type: 'number',
+              default: 2,
+              describe: 'Expand nested subflows to this depth (1 = subflow names only, 2 = one level, 3+ = deeper)',
+            }),
           handler: wrap(async (argv, app) => {
             const inspection = await app.sdk.inspectFlow(argv.identifier);
-            const formatted = formatFlowInspection(inspection, app.getEffectiveInstance());
+            const ctx = {
+              sdk: app.sdk,
+              instanceURL: app.getEffectiveInstance(),
+              depth: Math.max(1, Math.floor(argv.depth ?? 2)),
+              visited: new Set([inspection.flow.sysID]),
+            };
+            const formatted = await formatFlowInspection(inspection, ctx);
             const data = { ...inspection, _formatted: formatted };
             app.ok(data, {
               summary: `Flow: ${inspection.flow.name}`,
@@ -116,8 +139,9 @@ export function flowsCmd(wrap) {
   };
 }
 
-function formatFlowInspection(inspection, instanceURL) {
+async function formatFlowInspection(inspection, ctx) {
   const lines = [];
+  const instanceURL = ctx?.instanceURL || '';
   const flow = inspection.flow;
 
   lines.push('');
@@ -185,7 +209,7 @@ function formatFlowInspection(inspection, instanceURL) {
   lines.push('');
   lines.push('⚡ FLOW STRUCTURE');
   lines.push('─'.repeat(50));
-  const structureLines = formatFlowStructure(inspection);
+  const structureLines = await formatFlowStructure(inspection, ctx);
   lines.push(...structureLines);
   // Note limitation only when we couldn't reconstruct detail from the payload OR the gzip fallback
   const hasPayload = inspection.payload && Object.keys(inspection.payload).length > 0;
@@ -256,15 +280,15 @@ function inferFlowVersion(inspection) {
   return 'Unset';
 }
 
-function formatFlowStructure(inspection) {
+async function formatFlowStructure(inspection, ctx) {
   const payload = inspection.payload;
   if (Object.keys(payload).length > 0) {
-    return formatFlowStructureFromPayload(payload);
+    return formatFlowStructureFromPayload(payload, ctx);
   }
   return formatFlowStructureFallback(inspection);
 }
 
-function formatFlowStructureFromPayload(payload) {
+async function formatFlowStructureFromPayload(payload, ctx) {
   const childUIDs = new Set();
 
   function markChildren(items) {
@@ -314,10 +338,10 @@ function formatFlowStructureFromPayload(payload) {
   const lines = [];
   let stepNum = 1;
 
-  function walk(steps, indent) {
+  async function walk(steps, indent) {
     for (const step of steps) {
       const pad = '    '.repeat(indent);
-      lines.push(...formatStepLine(stepNum, pad, step));
+      lines.push(...await formatStepLine(stepNum, pad, step, ctx));
       stepNum++;
 
       if (step.stepType !== 'logic') continue;
@@ -334,11 +358,11 @@ function formatFlowStructureFromPayload(payload) {
         });
       }
       children.sort((a, b) => a.order - b.order);
-      walk(children, indent + 1);
+      await walk(children, indent + 1);
     }
   }
 
-  walk(roots, 0);
+  await walk(roots, 0);
   return lines;
 }
 
@@ -445,12 +469,12 @@ function formatFlowStructureFallback(inspection) {
   return lines;
 }
 
-function formatStepLine(stepNum, pad, step) {
+async function formatStepLine(stepNum, pad, step, ctx) {
   switch (step.stepType) {
     case 'logic':
       return formatLogicStep(stepNum, pad, step.data);
     case 'subflow':
-      return formatSubFlowStep(stepNum, pad, step.data);
+      return formatSubFlowStep(stepNum, pad, step.data, ctx);
     default:
       return formatActionStep(stepNum, pad, step.data);
   }
@@ -519,7 +543,7 @@ function formatActionStep(stepNum, pad, action) {
   return lines;
 }
 
-function formatSubFlowStep(stepNum, pad, subFlow) {
+export async function formatSubFlowStep(stepNum, pad, subFlow, ctx) {
   const lines = [];
   const subFlowName = firstNonEmpty(
     getNestedString(subFlow, 'subFlowType', 'fName'),
@@ -537,7 +561,43 @@ function formatSubFlowStep(stepNum, pad, subFlow) {
     lines.push(`${pad}${stepNum}. ↪ ${subFlowName}`);
   }
 
-  lines.push(`${pad}   jsn flows show "${subFlowName}"`);
+  // Recurse into the subflow when depth allows and we haven't already seen it.
+  // Note: `subflowSysId` on the instance is a snapshot id (sys_hub_flow_snapshot),
+  // NOT the flow id. The embedded `subFlow.parentFlow` is the real flow sys_id.
+  const subflowSysId = firstNonEmpty(
+    getNestedString(subFlow, 'subFlow', 'parentFlow'),
+    getStringField(subFlow, 'subflowSysId'),
+    getNestedString(subFlow, 'subFlow', 'sys_id'),
+    getStringField(subFlow, 'sys_id'),
+  );
+  const depth = ctx?.depth ?? 1;
+  const canRecurse = ctx?.sdk && subflowSysId && depth > 1 && !ctx.visited.has(subflowSysId);
+
+  if (!canRecurse) {
+    if (!subflowSysId) {
+      lines.push(`${pad}   (subflow definition not found)`);
+    } else if (depth <= 1) {
+      lines.push(`${pad}   jsn flows show "${subFlowName}"`);
+    }
+    return lines;
+  }
+
+  ctx.visited.add(subflowSysId);
+  try {
+    const subInspection = await ctx.sdk.inspectFlow(subflowSysId);
+    const subCtx = { ...ctx, depth: depth - 1 };
+    const subLines = await formatFlowStructure(subInspection, subCtx);
+    if (subLines.length === 0) {
+      lines.push(`${pad}   (no steps found)`);
+    } else {
+      const innerPad = pad + '   ';
+      for (const l of subLines) {
+        lines.push(innerPad + l.replace(/^ {2}/, ''));
+      }
+    }
+  } catch (e) {
+    lines.push(`${pad}   (could not load subflow: ${e.message})`);
+  }
   return lines;
 }
 

--- a/src/commands/dev/flows.js
+++ b/src/commands/dev/flows.js
@@ -139,7 +139,7 @@ export function flowsCmd(wrap) {
   };
 }
 
-async function formatFlowInspection(inspection, ctx) {
+export async function formatFlowInspection(inspection, ctx) {
   const lines = [];
   const instanceURL = ctx?.instanceURL || '';
   const flow = inspection.flow;
@@ -154,6 +154,27 @@ async function formatFlowInspection(inspection, ctx) {
   lines.push(`  Sys ID: ${flow.sysID}`);
   if (instanceURL && flow.sysID) {
     lines.push(`  Link: ${instanceURL}/sys_hub_flow.do?sys_id=${flow.sysID}`);
+  }
+
+  // Flow variables section
+  if (inspection.flowVariables && inspection.flowVariables.length > 0) {
+    const vars = [...inspection.flowVariables].sort((a, b) => {
+      const ao = parseInt(getStringField(a, 'order'), 10) || 0;
+      const bo = parseInt(getStringField(b, 'order'), 10) || 0;
+      return ao - bo;
+    });
+    lines.push('');
+    lines.push('▶ FLOW VARIABLES');
+    lines.push('─'.repeat(50));
+    for (const v of vars) {
+      const name = firstNonEmpty(getStringField(v, 'label'), getStringField(v, 'name'), 'Variable');
+      const typeName = firstNonEmpty(getStringField(v, 'type_label'), getStringField(v, 'type'), '');
+      if (typeName) {
+        lines.push(`  • ${name}: ${typeName}`);
+      } else {
+        lines.push(`  • ${name}`);
+      }
+    }
   }
 
   // Subflow I/O section

--- a/src/commands/dev/flows.js
+++ b/src/commands/dev/flows.js
@@ -109,9 +109,9 @@ export function flowsCmd(wrap) {
       console.log('');
       console.log('Run "jsn flows <command> --help" for details.');
       console.log('');
-      console.log('Note: Flow inspection detail varies. V2 flows (with payload)');
-      console.log('show full action inputs and conditions. Subflows and V1 flows');
-      console.log('show step names only.');
+      console.log('Note: Flow structure comes from the ProcessFlow API (the Flow');
+      console.log('Designer UI source), so V1, V2, and subflow definitions all');
+      console.log('render with full action inputs and conditions.');
     },
   };
 }
@@ -187,10 +187,12 @@ function formatFlowInspection(inspection, instanceURL) {
   lines.push('─'.repeat(50));
   const structureLines = formatFlowStructure(inspection);
   lines.push(...structureLines);
-  // Note limitation for V1/subflows without payload detail
-  if (!inspection.payload || Object.keys(inspection.payload).length === 0) {
+  // Note limitation only when we couldn't reconstruct detail from the payload OR the gzip fallback
+  const hasPayload = inspection.payload && Object.keys(inspection.payload).length > 0;
+  const hasDecodedLogic = (inspection.flowLogicInstances || []).some(l => l._decodedValues);
+  if (!hasPayload && !hasDecodedLogic) {
     lines.push('');
-    lines.push('  (step detail limited — this flow lacks a V2 payload)');
+    lines.push('  (step detail limited — no flow definition data available)');
   }
 
   lines.push('');
@@ -351,7 +353,7 @@ function formatFlowStructureFallback(inspection) {
         getStringField(action, 'display_text'),
         'Action',
       );
-      steps.push({ order: parseOrderField(action), text: name });
+      steps.push({ order: parseOrderField(action), text: name, comment: getStringField(action, 'comment') });
     }
   }
 
@@ -363,7 +365,12 @@ function formatFlowStructureFallback(inspection) {
         getStringField(logic, 'display_text'),
         'Logic',
       );
-      steps.push({ order: parseOrderField(logic), text: name });
+      steps.push({
+        order: parseOrderField(logic),
+        text: name,
+        comment: getStringField(logic, 'comment'),
+        decoded: logic._decodedValues || null,
+      });
     }
   }
 
@@ -385,7 +392,57 @@ function formatFlowStructureFallback(inspection) {
     return ['  (no steps found)'];
   }
 
-  return steps.map((step, i) => `${i + 1}. ${step.text}`);
+  const lines = [];
+  steps.forEach((step, i) => {
+    const num = `${i + 1}.`;
+    // Decoded gzip values carry the same input detail as a V2 payload
+    if (step.decoded && (step.text === 'If' || step.text === 'Else If')) {
+      let condition = '';
+      let conditionLabel = '';
+      if (Array.isArray(step.decoded.inputs)) {
+        for (const raw of step.decoded.inputs) {
+          if (!raw || typeof raw !== 'object') continue;
+          const inputName = getStringField(raw, 'name');
+          if (inputName === 'condition') {
+            condition = firstNonEmpty(getStringField(raw, 'displayValue'), getStringField(raw, 'value'));
+          }
+          if (inputName === 'condition_name') {
+            conditionLabel = firstNonEmpty(getStringField(raw, 'displayValue'), getStringField(raw, 'value'));
+          }
+        }
+      }
+      let displayText = step.text;
+      if (conditionLabel) {
+        displayText = `${step.text}: ${conditionLabel}`;
+      } else if (condition && condition.length < 60) {
+        displayText = `${step.text}: ${condition}`;
+      }
+      lines.push(`  ${num} ${displayText}`);
+      if (condition && condition.length >= 60 && !conditionLabel) {
+        lines.push(`     Condition: ${condition}`);
+      }
+    } else if (step.decoded && step.text === 'Set Flow Variables') {
+      lines.push(`  ${num} ${step.text}`);
+      const vars = step.decoded.variables || step.decoded.flowVariables;
+      if (Array.isArray(vars) && vars.length > 0) {
+        lines.push(`     Variables Set:`);
+        for (const raw of vars) {
+          if (!raw || typeof raw !== 'object') continue;
+          const varName = getStringField(raw, 'name');
+          const varValue = firstNonEmpty(getStringField(raw, 'displayValue'), getStringField(raw, 'value'));
+          if (!varName) continue;
+          lines.push(varValue ? `       • ${varName} = ${varValue}` : `       • ${varName}`);
+        }
+      }
+    } else {
+      lines.push(`  ${num} ${step.text}`);
+    }
+    if (step.comment) {
+      lines.push(`     Annotation: ${step.comment}`);
+    }
+  });
+
+  return lines;
 }
 
 function formatStepLine(stepNum, pad, step) {
@@ -425,8 +482,9 @@ function formatActionStep(stepNum, pad, action) {
     }
   }
 
+  const showsTableSuffix = tableName && (actionName === 'Update Record' || actionName === 'Create or Update Record');
   let actionDisplay = actionName;
-  if (tableName && actionName === 'Update Record') {
+  if (showsTableSuffix) {
     actionDisplay = actionName + ' - ' + tableName;
   }
 
@@ -441,7 +499,7 @@ function formatActionStep(stepNum, pad, action) {
     for (const raw of action.inputs) {
       if (!raw || typeof raw !== 'object') continue;
       const inputName = getStringField(raw, 'name');
-      if (inputName === 'table_name') continue;
+      if (inputName === 'table_name' && showsTableSuffix) continue;
 
       let inputValue = firstNonEmpty(getStringField(raw, 'displayValue'), getStringField(raw, 'value'));
       if (!inputValue) continue;
@@ -479,7 +537,7 @@ function formatSubFlowStep(stepNum, pad, subFlow) {
     lines.push(`${pad}${stepNum}. ↪ ${subFlowName}`);
   }
 
-  lines.push(`${pad}   jsn flows "${subFlowName}"`);
+  lines.push(`${pad}   jsn flows show "${subFlowName}"`);
   return lines;
 }
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -245,6 +245,7 @@ export class SDKClient {
       subFlowInstances: [],
       flowInputs: [],
       flowOutputs: [],
+      flowVariables: [],
     };
 
     // 2) Prefer the ProcessFlow API — the Flow Designer UI's own source.
@@ -370,6 +371,20 @@ export class SDKClient {
       outputsQuery.set('sysparm_limit', '200');
       const records = await this.list('sys_hub_flow_output', outputsQuery);
       if (records) inspection.flowOutputs = records;
+    }
+
+    // Flow variables fallback (payload.flowVariables may be empty on legacy
+    // payload shapes, but sys_hub_flow_variable rows exist for every flow).
+    // Note: the table only carries name/label/order — type is empty there, so
+    // prefer payload.flowVariables when available.
+    if (!inspection.flowVariables || inspection.flowVariables.length === 0) {
+      const varsQuery = new URLSearchParams();
+      varsQuery.set('sysparm_display_value', 'all');
+      varsQuery.set('sysparm_query', `model=${flowSysID}^ORDERBYorder`);
+      varsQuery.set('sysparm_fields', 'sys_id,name,label,type,order');
+      varsQuery.set('sysparm_limit', '200');
+      const records = await this.list('sys_hub_flow_variable', varsQuery);
+      if (records) inspection.flowVariables = records;
     }
 
     return inspection;
@@ -634,6 +649,9 @@ function extractPayloadData(inspection, payload) {
 
   const outputs = toMapSlice(payload.outputs);
   if (outputs) inspection.flowOutputs = outputs;
+
+  const flowVariables = toMapSlice(payload.flowVariables);
+  if (flowVariables) inspection.flowVariables = flowVariables;
 
   const triggerInstances = payload.triggerInstances;
   if (!Array.isArray(triggerInstances) || triggerInstances.length === 0) return;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1,5 +1,6 @@
 // ServiceNow REST API client
 
+import { gunzipSync } from 'node:zlib';
 import { errAuth, errAPI, errNetwork } from './errors.js';
 import { getStringField } from './helpers.js';
 
@@ -246,28 +247,51 @@ export class SDKClient {
       flowOutputs: [],
     };
 
-    // 2) Fetch latest flow version
-    const versionQuery = new URLSearchParams();
-    versionQuery.set('sysparm_display_value', 'all');
-    versionQuery.set('sysparm_limit', '1');
-    versionQuery.set('sysparm_query', `flow=${flowSysID}^ORDERBYDESCsys_updated_on`);
-    versionQuery.set('sysparm_fields', 'sys_id,flow,version,payload,sys_updated_on');
-
-    const versionRecords = await this.list('sys_hub_flow_version', versionQuery);
-    if (versionRecords && versionRecords.length > 0) {
-      inspection.version = versionRecords[0];
-      if (!inspection.flow.version) {
-        inspection.flow.version = getStringField(versionRecords[0], 'version');
+    // 2) Prefer the ProcessFlow API — the Flow Designer UI's own source.
+    //    Returns complete structure for both V2 and legacy V1 flows (the
+    //    version payload field is empty for V1 flows).
+    let payloadLoaded = false;
+    try {
+      const pfResponse = await this.request(`${this.baseURL}/api/now/processflow/flow/${flowSysID}`, { method: 'GET' });
+      const pfData = pfResponse?.result?.data;
+      if (pfData && typeof pfData === 'object' && !pfResponse?.result?.errorMessage) {
+        inspection.payload = pfData;
+        if (!inspection.flow.version) {
+          const pfVersion = getStringField(pfData, 'version');
+          if (pfVersion) inspection.flow.version = pfVersion;
+        }
+        hydrateFlowBlocks(inspection.payload);
+        extractPayloadData(inspection, inspection.payload);
+        payloadLoaded = true;
       }
+    } catch {
+      // ProcessFlow API may not exist on older instances — fall through
+    }
 
-      const payload = getStringField(versionRecords[0], 'payload');
-      if (payload) {
-        try {
-          const payloadData = JSON.parse(payload);
-          inspection.payload = payloadData;
-          extractPayloadData(inspection, payloadData);
-        } catch {
-          // ignore parse error
+    // 2b) Fallback: latest flow version payload
+    if (!payloadLoaded) {
+      const versionQuery = new URLSearchParams();
+      versionQuery.set('sysparm_display_value', 'all');
+      versionQuery.set('sysparm_limit', '1');
+      versionQuery.set('sysparm_query', `flow=${flowSysID}^ORDERBYDESCsys_updated_on`);
+      versionQuery.set('sysparm_fields', 'sys_id,flow,version,payload,sys_updated_on');
+
+      const versionRecords = await this.list('sys_hub_flow_version', versionQuery);
+      if (versionRecords && versionRecords.length > 0) {
+        inspection.version = versionRecords[0];
+        if (!inspection.flow.version) {
+          inspection.flow.version = getStringField(versionRecords[0], 'version');
+        }
+
+        const payload = getStringField(versionRecords[0], 'payload');
+        if (payload) {
+          try {
+            const payloadData = JSON.parse(payload);
+            inspection.payload = payloadData;
+            extractPayloadData(inspection, payloadData);
+          } catch {
+            // ignore parse error
+          }
         }
       }
     }
@@ -295,15 +319,24 @@ export class SDKClient {
     }
 
     if (!inspection.flowLogicInstances || inspection.flowLogicInstances.length === 0) {
-      const logicTables = ['sys_hub_flow_logic', 'sys_hub_flow_logic_instance_v2'];
-      for (const table of logicTables) {
+      const logicTables = [
+        { table: 'sys_hub_flow_logic', payloadField: 'inputs' },
+        { table: 'sys_hub_flow_logic_instance_v2', payloadField: 'values' },
+      ];
+      for (const { table, payloadField } of logicTables) {
         const logicQuery = new URLSearchParams();
         logicQuery.set('sysparm_display_value', 'all');
         logicQuery.set('sysparm_query', `flow=${flowSysID}^ORDERBYorder`);
-        logicQuery.set('sysparm_fields', 'sys_id,order,name,display_text,comment,parent_ui_id,logic_definition');
+        logicQuery.set('sysparm_fields', `sys_id,order,name,display_text,comment,parent_ui_id,logic_definition,${payloadField}`);
         logicQuery.set('sysparm_limit', '200');
         const records = await this.list(table, logicQuery);
-        if (records) inspection.flowLogicInstances.push(...records);
+        if (records) {
+          for (const rec of records) {
+            const decoded = decodeGzipJson(rec[payloadField]);
+            if (decoded) rec._decodedValues = decoded;
+          }
+          inspection.flowLogicInstances.push(...records);
+        }
       }
       inspection.flowLogicInstances.sort((a, b) => parseOrderField(a) - parseOrderField(b));
     }
@@ -634,8 +667,72 @@ function toMapSlice(v) {
   return v.filter(item => item && typeof item === 'object');
 }
 
+/**
+ * The ProcessFlow API returns flow structure as flat arrays where children
+ * reference their parent logic step via a `parent` / `parent_ui_id` field
+ * (a uiUniqueIdentifier value). The payload-based renderer expects nested
+ * `flowBlock` arrays on each logic instance. Rebuild that nesting here so
+ * both data sources render identically.
+ */
+export function hydrateFlowBlocks(payload) {
+  const blockKeys = ['actionInstances', 'flowLogicInstances', 'subFlowInstances'];
+  const items = [];
+  for (const key of blockKeys) {
+    if (Array.isArray(payload[key])) {
+      for (const item of payload[key]) {
+        if (item && typeof item === 'object') items.push(item);
+      }
+    }
+  }
+  if (items.length === 0) return;
+
+  // If the payload already has nested flowBlock arrays (version-payload
+  // shape), leave it alone.
+  const logicItems = Array.isArray(payload.flowLogicInstances) ? payload.flowLogicInstances : [];
+  if (logicItems.some(l => l && typeof l === 'object' && Array.isArray(l.flowBlock))) return;
+
+  // Build parent → children map keyed by uiUniqueIdentifier
+  const childrenByParent = new Map();
+  for (const item of items) {
+    const parentId = getStringField(item, 'parent_ui_id') || getStringField(item, 'parent');
+    if (!parentId) continue;
+    if (!childrenByParent.has(parentId)) childrenByParent.set(parentId, []);
+    childrenByParent.get(parentId).push(item);
+  }
+
+  // Attach sorted flowBlock to each logic instance
+  for (const logic of logicItems) {
+    if (!logic || typeof logic !== 'object') continue;
+    const uid = getStringField(logic, 'uiUniqueIdentifier');
+    const children = uid ? childrenByParent.get(uid) : null;
+    if (Array.isArray(children) && children.length > 0) {
+      children.sort((a, b) => parseOrderField(a) - parseOrderField(b));
+      logic.flowBlock = children;
+    }
+  }
+}
+
 function parseOrderField(record) {
   const order = getStringField(record, 'order');
   const n = parseInt(order, 10);
   return isNaN(n) ? 0 : n;
+}
+
+/**
+ * Decode a ServiceNow flow-logic "values" field: base64-gzip JSON.
+ * Returns the parsed object, or null when the field is empty / not gzip / unparseable.
+ */
+export function decodeGzipJson(value) {
+  if (!value) return null;
+  const s = (typeof value === 'object' && value !== null)
+    ? (value.value ?? value.display_value ?? '')
+    : String(value);
+  const trimmed = s.trim();
+  if (!trimmed.startsWith('H4sI')) return null; // not gzip base64
+  try {
+    const decoded = gunzipSync(Buffer.from(trimmed, 'base64')).toString('utf-8');
+    return JSON.parse(decoded);
+  } catch {
+    return null;
+  }
 }

--- a/test/sdk-flows.test.js
+++ b/test/sdk-flows.test.js
@@ -129,3 +129,35 @@ test('formatSubFlowStep guards against cycles via visited set', async () => {
   await formatSubFlowStep(1, '', subFlow, ctx);
   assert.equal(called, false, 'should not re-fetch an already-visited subflow');
 });
+
+test('formatActionStep keeps long single-line values untruncated', async () => {
+  const { formatActionStep } = await import('../src/commands/dev/flows.js');
+  const longValue = 'x'.repeat(200);
+  const action = {
+    actionType: { fName: 'Create Record' },
+    inputs: [
+      { name: 'short_description', displayValue: longValue, value: longValue },
+    ],
+  };
+  const lines = formatActionStep(1, '', action);
+  const line = lines.find(l => l.includes('short_description'));
+  assert.ok(line.includes(longValue), 'long value should appear in full, not truncated');
+  assert.ok(!line.includes('...'), 'no ellipsis truncation');
+  assert.equal(lines.length, 2, 'name line + one value line');
+});
+
+test('formatActionStep splits carrot-separated fields onto separate lines', async () => {
+  const { formatActionStep } = await import('../src/commands/dev/flows.js');
+  const action = {
+    actionType: { fName: 'Update Record' },
+    inputs: [
+      { name: 'fields', displayValue: 'state=7^work_notes=Auto-closing: No application found^priority=1', value: 'state=7^work_notes=Auto-closing: No application found^priority=1' },
+    ],
+  };
+  const lines = formatActionStep(1, '', action);
+  const fieldLines = lines.filter(l => l.includes('fields:'));
+  assert.equal(fieldLines.length, 3, 'each carrot field gets its own line');
+  assert.ok(fieldLines.some(l => l.includes('state=7')), 'first field present');
+  assert.ok(fieldLines.some(l => l.includes('work_notes=Auto-closing: No application found')), 'second field present, untruncated');
+  assert.ok(fieldLines.some(l => l.includes('priority=1')), 'third field present');
+});

--- a/test/sdk-flows.test.js
+++ b/test/sdk-flows.test.js
@@ -73,3 +73,59 @@ test('hydrateFlowBlocks handles empty input', () => {
   hydrateFlowBlocks(payload);
   assert.deepEqual(payload, {});
 });
+
+test('formatSubFlowStep resolves parentFlow (real flow id) over subflowSysId (snapshot id)', async () => {
+  const { formatSubFlowStep } = await import('../src/commands/dev/flows.js');
+  const subFlow = {
+    subflowSysId: 'snapshot-123', // snapshot id — should NOT be used
+    subFlow: { parentFlow: 'flow-456', name: 'My Subflow' },
+    name: 'My Subflow',
+  };
+  let resolvedId = null;
+  const ctx = {
+    sdk: { inspectFlow: async (id) => { resolvedId = id; return { flow: { sysID: id }, payload: {} }; } },
+    instanceURL: 'https://x.service-now.com',
+    depth: 2,
+    visited: new Set(['parent-flow']),
+  };
+  const lines = await formatSubFlowStep(1, '', subFlow, ctx);
+  assert.equal(resolvedId, 'flow-456', 'should recurse into subFlow.parentFlow, not subflowSysId');
+  assert.ok(lines[0].includes('My Subflow'), 'first line names the subflow');
+});
+
+test('formatSubFlowStep shows hint at depth 1 instead of recursing', async () => {
+  const { formatSubFlowStep } = await import('../src/commands/dev/flows.js');
+  const subFlow = {
+    subflowSysId: 'snapshot-123',
+    subFlow: { parentFlow: 'flow-456', name: 'My Subflow' },
+    name: 'My Subflow',
+  };
+  let called = false;
+  const ctx = {
+    sdk: { inspectFlow: async () => { called = true; return {}; } },
+    instanceURL: 'https://x.service-now.com',
+    depth: 1,
+    visited: new Set(['parent-flow']),
+  };
+  const lines = await formatSubFlowStep(1, '', subFlow, ctx);
+  assert.equal(called, false, 'should not fetch at depth 1');
+  assert.ok(lines.some(l => l.includes('jsn flows show')), 'should show drill hint');
+});
+
+test('formatSubFlowStep guards against cycles via visited set', async () => {
+  const { formatSubFlowStep } = await import('../src/commands/dev/flows.js');
+  const subFlow = {
+    subflowSysId: 'snapshot-123',
+    subFlow: { parentFlow: 'flow-456', name: 'Loop Subflow' },
+    name: 'Loop Subflow',
+  };
+  let called = false;
+  const ctx = {
+    sdk: { inspectFlow: async () => { called = true; return {}; } },
+    instanceURL: 'https://x.service-now.com',
+    depth: 3,
+    visited: new Set(['flow-456']), // already visited → cycle
+  };
+  await formatSubFlowStep(1, '', subFlow, ctx);
+  assert.equal(called, false, 'should not re-fetch an already-visited subflow');
+});

--- a/test/sdk-flows.test.js
+++ b/test/sdk-flows.test.js
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { gzipSync } from 'node:zlib';
+import { decodeGzipJson, hydrateFlowBlocks } from '../src/sdk.js';
+
+function gzipB64(obj) {
+  return gzipSync(Buffer.from(JSON.stringify(obj), 'utf-8')).toString('base64');
+}
+
+test('decodeGzipJson decodes base64-gzip JSON with surrounding whitespace', () => {
+  const payload = { inputs: [{ name: 'condition', value: '{{x}}ISNOTEMPTY' }], variables: [] };
+  const raw = `\n\t\t\t${gzipB64(payload)}`;
+  const result = decodeGzipJson(raw);
+  assert.deepEqual(result, payload);
+});
+
+test('decodeGzipJson handles display_value/value object form', () => {
+  const payload = { inputs: [] };
+  const result = decodeGzipJson({ display_value: gzipB64(payload), value: gzipB64(payload) });
+  assert.deepEqual(result, payload);
+});
+
+test('decodeGzipJson returns null for empty input', () => {
+  assert.equal(decodeGzipJson(''), null);
+  assert.equal(decodeGzipJson(null), null);
+  assert.equal(decodeGzipJson(undefined), null);
+  assert.equal(decodeGzipJson('   '), null);
+});
+
+test('decodeGzipJson returns null for non-gzip strings', () => {
+  assert.equal(decodeGzipJson('plain json {"a":1}'), null);
+  assert.equal(decodeGzipJson('H4sI not-valid-base64'), null);
+});
+
+test('decodeGzipJson returns null for corrupt gzip', () => {
+  assert.equal(decodeGzipJson('H4sIAAAAAAAA/w=='), null);
+});
+
+test('hydrateFlowBlocks builds flowBlock nesting from flat parent links', () => {
+  const payload = {
+    flowLogicInstances: [
+      { uiUniqueIdentifier: 'if-1', flowLogicDefinition: { name: 'If' }, order: '1' },
+      { uiUniqueIdentifier: 'if-2', flowLogicDefinition: { name: 'If' }, order: '3', parent: 'if-1' },
+    ],
+    actionInstances: [
+      { name: 'Update Record', order: '2', parent: 'if-1' },
+      { name: 'Log', order: '4', parent: 'if-2' },
+    ],
+  };
+  hydrateFlowBlocks(payload);
+  const if1 = payload.flowLogicInstances[0];
+  const if2 = payload.flowLogicInstances[1];
+  assert.ok(Array.isArray(if1.flowBlock), 'If-1 should have a flowBlock');
+  assert.equal(if1.flowBlock.length, 2, 'If-1 should contain action + nested If');
+  assert.deepEqual(if1.flowBlock.map(x => x.name ?? x.uiUniqueIdentifier), ['Update Record', 'if-2']);
+  assert.ok(Array.isArray(if2.flowBlock), 'If-2 should have a flowBlock');
+  assert.deepEqual(if2.flowBlock.map(x => x.name), ['Log']);
+});
+
+test('hydrateFlowBlocks leaves existing flowBlock arrays alone (version-payload shape)', () => {
+  const payload = {
+    flowLogicInstances: [
+      { uiUniqueIdentifier: 'if-1', flowLogicDefinition: { name: 'If' }, flowBlock: [{ name: 'Update Record' }] },
+    ],
+    actionInstances: [{ name: 'Update Record', parent: 'if-1' }],
+  };
+  hydrateFlowBlocks(payload);
+  assert.deepEqual(payload.flowLogicInstances[0].flowBlock.map(x => x.name), ['Update Record']);
+});
+
+test('hydrateFlowBlocks handles empty input', () => {
+  const payload = {};
+  hydrateFlowBlocks(payload);
+  assert.deepEqual(payload, {});
+});

--- a/test/sdk-flows.test.js
+++ b/test/sdk-flows.test.js
@@ -74,6 +74,49 @@ test('hydrateFlowBlocks handles empty input', () => {
   assert.deepEqual(payload, {});
 });
 
+test('formatFlowInspection renders flow variables with labels and types', async () => {
+  const { formatFlowInspection } = await import('../src/commands/dev/flows.js');
+  const inspection = {
+    flow: { name: 'jace flow', active: true, version: '2', type: 'Flow', sysID: 'abc123' },
+    version: {},
+    payload: {},
+    triggerInstances: [],
+    actionInstances: [],
+    flowLogicInstances: [],
+    subFlowInstances: [],
+    flowInputs: [],
+    flowOutputs: [],
+    flowVariables: [
+      { name: 'food', label: 'food', type: 'string', type_label: 'String', order: 1 },
+      { name: 'quantity', label: 'quantity', type: 'integer', type_label: 'Integer', order: 2 },
+      { name: 'ordering_person', label: 'ordering person', type: 'reference', type_label: 'Reference', order: 3 },
+    ],
+  };
+  const output = await formatFlowInspection(inspection, { instanceURL: '', depth: 1, visited: new Set() });
+  assert.ok(output.includes('▶ FLOW VARIABLES'), 'section header present');
+  assert.ok(output.includes('• food: String'), 'food variable with type');
+  assert.ok(output.includes('• quantity: Integer'), 'quantity variable with type');
+  assert.ok(output.includes('• ordering person: Reference'), 'ordering person variable with type');
+});
+
+test('formatFlowInspection omits variables section when none exist', async () => {
+  const { formatFlowInspection } = await import('../src/commands/dev/flows.js');
+  const inspection = {
+    flow: { name: 'plain', active: true, version: '2', type: 'Flow', sysID: 'abc123' },
+    version: {},
+    payload: {},
+    triggerInstances: [],
+    actionInstances: [],
+    flowLogicInstances: [],
+    subFlowInstances: [],
+    flowInputs: [],
+    flowOutputs: [],
+    flowVariables: [],
+  };
+  const output = await formatFlowInspection(inspection, { instanceURL: '', depth: 1, visited: new Set() });
+  assert.ok(!output.includes('FLOW VARIABLES'), 'no section when no variables');
+});
+
 test('formatSubFlowStep resolves parentFlow (real flow id) over subflowSysId (snapshot id)', async () => {
   const { formatSubFlowStep } = await import('../src/commands/dev/flows.js');
   const subFlow = {


### PR DESCRIPTION
## What

Rebuilds and extends the `jsn dev flows` rendering pipeline in one stack of 5 commits (originally merged in #128–#130, then unmade by a mirror rewind; the two newest commits were never PR'd).

1. **`feat(flows): render full flow structure via ProcessFlow API`** (was #128) — render the complete flow structure from the ProcessFlow API instead of partial data
2. **`feat(flows): expand nested subflows with --depth flag`** (was #129) — recursively expand nested subflows, controlled by `--depth`
3. **`fix(flows): stop truncating values, split ^-separated fields`** (was #130) — don't truncate long values; split `^`-separated fields onto their own lines
4. **`chore: bump to 3.4.3`**
5. **`feat(flows): render flow variables with labels and types`** — extract `payload.flowVariables` (ProcessFlow API) with label/type/type_label/order, falling back to `sys_hub_flow_variable` rows; renders a FLOW VARIABLES section after the header, sorted by order, skipped when empty

## Why a single PR

All five commits share the same file (`src/commands/dev/flows.js` + version bump) and were originally one working line; stacking them keeps the history coherent and avoids re-opening three PRs plus a new one.

## Verification

- Rebased cleanly onto current `main` (includes #134 FTS5 + #135 OAuth fixes)
- `npm test`: **203 pass, 0 fail** (1 skipped = integration)
- No conflicts with the better-sqlite3 / auth changes on main