### PR TITLE
chore(release): bump version to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.4.2",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jacebenson/jsn",
-      "version": "3.4.2",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jacebenson/jsn",
-  "version": "3.4.3",
+  "version": "4.0.0",
   "description": "A command-line interface for ServiceNow that follows the Unix philosophy: simple, composable, and scriptable.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Bump version to **4.0.0** (package.json + package-lock.json) for the upcoming major release.

## Why

This release contains breaking changes (see #137): the `jsn profiles` command is removed, `auth logout` semantics changed (new `auth remove`), `yolo` removed, `read_only` now actually blocks mutations, and bare `auth login` prompts with a picker. That's a major bump, not a patch or minor.

## Sequencing note

Merge **#137 first**, then this PR — that way `main` only claims 4.0.0 once the breaking changes are actually in.

⚠️ After both merge, **do NOT run `npm run release -- major`** — `scripts/release.js` calls `npm version major`, which would bump 4.0.0 → 5.0.0. Instead, tag and publish directly:

```bash
git tag v4.0.0 && git push origin v4.0.0
npm publish --access public
```

(or cherry-pick this bump into the release run if you prefer the script path)
