### PR TITLE
fix(skill): repair dead fetch URL, sync bundled skill to v4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Documentation for JSN CLI
 
-> JSN v3.x — Node.js — branch: `nodejs`
+> JSN v4.x — Node.js — branch: `main`
 
 This document provides guidance for AI agents using the JSN CLI to interact with ServiceNow.
 
@@ -396,6 +396,8 @@ node --test $(find test -name '*inspect*')
 # Run with lint check
 npm run lint && npm test
 ```
+
+**Test env vars:** `JSN_HERMES_BASE_DIR` points skill tests at a temp `.hermes` tree (used by `test/skill.test.js`); `JSN_NO_VERSION_CHECK=1` and `JSN_NO_SKILL_CHECK=1` disable the daily npm/skill checks.
 
 ## AI Agent Integration
 

--- a/skills/servicenow/SKILL.md
+++ b/skills/servicenow/SKILL.md
@@ -14,7 +14,7 @@ compatibility: |
   Works with Claude Code, OpenCode, Cursor, and agentskills-compatible tools.
 metadata:
   author: jacebenson
-  version: "3.1.1"
+  version: "4.0.0"
   repository: https://github.com/jacebenson/jsn
 ---
 
@@ -69,7 +69,7 @@ Pick the most specific tool for the job. **Never default to eval** — it's the 
 | **Access** | `acls`, `b4rules`, `roles`, `groups`, `users` |
 | **UX** | `forms` (section/element layout), `lists`, `clientscripts`, `uipolicies` |
 | **Data** | `tables`, `columns`, `includes`, `logs`, `properties`, `records` |
-| **Config** | `setup`, `auth`, `profiles`, `updatesets`, `scopes` |
+| **Config** | `setup`, `auth`, `updatesets`, `scopes` |
 | **Docs** | `docs sync`, `docs status`, `docs search`, `docs serve` |
 | **Developer** | `eval`, `rest`, `skill`, `version` |
 

--- a/src/commands/skill.js
+++ b/src/commands/skill.js
@@ -14,7 +14,7 @@ const SKILL_REPO_PATH = path.join(
   '..', '..', 'skills', SKILL_NAME, 'SKILL.md'
 );
 
-const SKILL_RAW_URL = 'https://raw.githubusercontent.com/jacebenson/jsn/nodejs/skills/servicenow/SKILL.md';
+const SKILL_RAW_URL = 'https://raw.githubusercontent.com/jacebenson/jsn/main/skills/servicenow/SKILL.md';
 
 /**
  * Resolve the user's real home directory, even when Hermes overrides $HOME.


### PR DESCRIPTION
**Problem:** `jsn skill fetch` / `jsn skill install` are broken. `SKILL_RAW_URL` points at the `nodejs` branch, which no longer exists (removed when CI moved to `main`). Every fetch 404s.

**Also fixed:**
- Bundled skill Config table still listed `jsn profiles` (removed in #137)
- Bundled skill version bumped 3.1.1 → 4.0.0 so `jsn skill check` correctly flags stale installs
- AGENTS.md header said `v3.x — branch: nodejs` (dead branch)
- Documented `JSN_HERMES_BASE_DIR` and the check-suppression env vars under Running Tests (flagged in review as a hidden landmine for contributors)

No code behavior changes beyond the URL.