### PR TITLE
chore(lint): clear all 24 pre-existing eslint errors

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,7 @@ import { hideBin } from 'yargs/helpers';
 import process from 'node:process';
 import path from 'node:path';
 import fs from 'node:fs';
-import { loadConfig, getEffectiveInstance, getActiveProfile, globalConfigDir } from './config.js';
+import { loadConfig, getActiveProfile, globalConfigDir } from './config.js';
 import { App } from './app.js';
 import { renderHelp } from './help.js';
 import { isMutationCommand } from './mutations.js';
@@ -93,14 +93,6 @@ function wrap(handler) {
 export function buildCLI() {
   const cfg = loadConfig();
   const app = new App(cfg);
-
-  // Resolve instance once
-  let effectiveInstance;
-  try {
-    effectiveInstance = getEffectiveInstance(cfg);
-  } catch {
-    effectiveInstance = null;
-  }
 
   return yargs(hideBin(process.argv))
     .scriptName('jsn')

--- a/src/commands/catalog.js
+++ b/src/commands/catalog.js
@@ -16,7 +16,7 @@ export function catalogCmd(wrap) {
             .option('short-description', { alias: 'd', type: 'string' })
             .option('category', { alias: 'c', type: 'string' })
             .option('variable', { alias: 'v', type: 'array', describe: 'Variable: "name:type:label"' })
-            .option('variables', { type: 'string', describe: 'JSON for submit_produce: {\"key\":\"value\"}' }),
+            .option('variables', { type: 'string', describe: 'JSON for submit_produce: {"key":"value"}' }),
           handler: wrap(async (argv, app) => {
             app.requireInstance();
 
@@ -215,8 +215,6 @@ async function showItem(app, sysID) {
   const wfName = getStringField(item, 'workflow') || '';
   const wfID = item.workflow?.value || '';
   const planName = getStringField(item, 'delivery_plan') || getStringField(item, 'execution_plan') || '';
-  const planID = item.delivery_plan?.value || item.execution_plan?.value || '';
-
   app.ok({
     name: getStringField(item, 'name'),
     short_description: getStringField(item, 'short_description'),

--- a/src/commands/dev/_generic.js
+++ b/src/commands/dev/_generic.js
@@ -1,5 +1,6 @@
 // Generic dev subcommand builder for table-based CRUD
 
+import readline from 'node:readline';
 import { formatRecordForDisplay, getStringField, isHexString, parseDataArg } from '../../helpers.js';
 import { getCurrentUser, getCurrentApplication } from '../../context.js';
 import { paginatedSearch } from '../../paginated-search.js';
@@ -81,7 +82,6 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
   const readOnly = opts.readOnly || false;
   const scopeValidation = opts.scopeValidation || false;
   const extraQuery = opts.extraQuery || '';
-  const formatLabel = opts.formatLabel || null;
   const showSummary = opts.showSummary || ((record, id) => `${singular.charAt(0).toUpperCase() + singular.slice(1)}: ${getStringField(record, 'name') || id}`);
   const showBreadcrumbs = opts.showBreadcrumbs || ((record, id) => {
     const crumbs = [
@@ -120,7 +120,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
               totalCount = await app.sdk.aggregateCount(table, extraQuery || '');
             } catch { /* non-critical */ }
 
-            const source = async (term, offset, { signal } = {}) => {
+            const source = async (term, offset, { signal: _signal } = {}) => {
               const params = new URLSearchParams();
               params.set('sysparm_limit', String(limit));
               params.set('sysparm_display_value', 'all');

--- a/src/commands/dev/forms.js
+++ b/src/commands/dev/forms.js
@@ -22,15 +22,6 @@ function getIntValue(record, key) {
   return 0;
 }
 
-function getBoolValue(record, key) {
-  if (!record || typeof record !== 'object') return false;
-  const val = record[key];
-  if (typeof val === 'boolean') return val;
-  if (typeof val === 'string') return val === 'true';
-  if (typeof val === 'object' && val.value != null) return String(val.value) === 'true';
-  return false;
-}
-
 async function showForm(app, table, viewName) {
   // 1) Look up the view
   const viewParams = new URLSearchParams();
@@ -87,8 +78,6 @@ async function showForm(app, table, viewName) {
   }
 
   sectionsOut.sort((a, b) => a.position - b.position);
-
-  const totalElements = sectionsOut.reduce((sum, s) => sum + s.elements.length, 0);
 
   // Build formatted output
   const lines = [];

--- a/src/commands/dev/import.js
+++ b/src/commands/dev/import.js
@@ -20,7 +20,7 @@ export const importCmd = (wrap) => buildDevCmd('import', 'sys_import_set', ['imp
         const rows = await app.sdk.list('sys_import_set_row', rp);
         console.log(`  Import rows: ${rows.length}`);
         console.log(`    → jsn records list --table sys_import_set_row --query "sys_import_set=${sysID}" --limit 200`);
-      } catch (err) {
+      } catch {
         console.log(`  Import rows: (unavailable)`);
       }
     },

--- a/src/commands/dev/lists.js
+++ b/src/commands/dev/lists.js
@@ -17,7 +17,7 @@ export function listsCmd(wrap) {
           handler: wrap(async (argv, app) => {
             app.requireInstance();
             let table = argv.table;
-            let viewSysID = null;
+            let viewSysID;
 
             // If no table, pick one interactively
             if (!table) {
@@ -76,7 +76,7 @@ export function listsCmd(wrap) {
             const table = argv.table;
 
             // Resolve view sys_id
-            let viewSysID = '';
+            let viewSysID;
             const vp = new URLSearchParams();
             vp.set('sysparm_limit', '1'); vp.set('sysparm_fields', 'sys_id');
             vp.set('sysparm_query', `name=${argv.view}^name=${table}`);

--- a/src/commands/groups.js
+++ b/src/commands/groups.js
@@ -32,13 +32,13 @@ export function groupsCmd(wrap) {
                 cp.set('sysparm_query', `group=${sysID}`); cp.set('sysparm_limit', '0'); cp.set('sysparm_fields', 'sys_id');
                 const members = await app.sdk.list('sys_user_grmember', cp);
                 memberCount = members.length;
-              } catch {}
+              } catch { /* non-critical */ }
               try {
                 const rp = new URLSearchParams();
                 rp.set('sysparm_query', `group=${sysID}`); rp.set('sysparm_limit', '0'); rp.set('sysparm_fields', 'sys_id');
                 const roles = await app.sdk.list('sys_group_has_role', rp);
                 roleCount = roles.length;
-              } catch {}
+              } catch { /* non-critical */ }
 
               picked._context = { instance_url: app.getEffectiveInstance(), table: 'sys_user_group' };
               return app.ok(picked, {

--- a/src/commands/skill.js
+++ b/src/commands/skill.js
@@ -62,11 +62,6 @@ function hermesSkillDir() {
   return path.join(base, 'skills', SKILL_NAME);
 }
 
-/** Resolve the installed SKILL.md path for Hermes. */
-function hermesSkillPath() {
-  return path.join(hermesSkillDir(), 'SKILL.md');
-}
-
 // Known agent skill directories (personal/user-level)
 // Keyed by agent name for the --target flag
 // Each value is the directory for the <name>/SKILL.md file

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -89,12 +89,7 @@ export function resolveFieldsParam(columns) {
  * @param {string} opts.labelField — field used to match selection (default: 'name')
  * @returns {Promise<void>|null} null if no selection made or non-interactive
  */
-function vowelArticle(word) {
-  const first = word.charAt(0).toLowerCase();
-  return first === 'a' || first === 'e' || first === 'i' || first === 'o' || first === 'u' ? 'an' : 'a';
-}
-
-export async function interactiveList({ app, table, singular, columns, limit = 50, query = '', formatLabel, labelField = 'name' }) {
+export async function interactiveList({ app, table, singular, columns, limit = 50, _query = '', formatLabel, labelField = 'name' }) {
   app.requireInstance();
   const effectiveFormat = app.output.getFormat() === FormatAuto ? (isTTY(process.stdout) ? FormatAuto : FormatAuto) : app.output.getFormat();
   if (effectiveFormat !== FormatAuto || !isTTY(process.stdout) || !isTTY(process.stdin)) {
@@ -105,7 +100,7 @@ export async function interactiveList({ app, table, singular, columns, limit = 5
   const pickerFields = pickerColumns.join(',');
 
   // Get total count
-  let totalCount = 0;
+  let totalCount;
   try {
     totalCount = await app.sdk.aggregateCount(table, '');
   } catch {
@@ -114,7 +109,7 @@ export async function interactiveList({ app, table, singular, columns, limit = 5
   if (totalCount === 0) return null;
 
   // Paginated source adapter: (term, offset, { signal }) => choices[]
-  async function serverSource(term, offset, { signal } = {}) {
+  async function serverSource(term, offset, { signal: _signal } = {}) {
     try {
       const params = new URLSearchParams();
       params.set('sysparm_limit', String(limit));

--- a/src/paginated-search.js
+++ b/src/paginated-search.js
@@ -43,7 +43,7 @@ export const paginatedSearch = createPrompt((config, done) => {
           setActive(0);
           setStatus('done');
         }
-      } catch (err) {
+      } catch {
         if (!controller.signal.aborted) {
           setStatus('done');
           setChoices([]);

--- a/test/docs.test.js
+++ b/test/docs.test.js
@@ -107,7 +107,7 @@ describe('Docs status — no DB', () => {
     const statusCmd = all.find((c) => c.command === 'status');
 
     let result = null;
-    const app = { ok: (data, opts) => { result = data; } };
+    const app = { ok: (data) => { result = data; } };
     const handler = statusCmd.handler;
     await handler({}, app);
 
@@ -133,7 +133,6 @@ describe('Docs sync — incremental path', () => {
       return;
     }
 
-    const result = syncDocs({ noIngest: true }); // just pull, don't rebuild
     // With noIngest, we won't hit the incremental branch — need to test the real path.
     // Actually: noIngest skips both. Let's just verify the import works and the function
     // returns the right shape for the incremental case.


### PR DESCRIPTION
**Goal:** `npm run lint` → 0 errors (was 24).

**What was fixed (all behavior-neutral unless noted):**
- **Real bug:** `src/commands/dev/_generic.js` used `readline.createInterface` without importing `readline` — the TTY delete-confirmation path threw `ReferenceError`. Added the import.
- Removed dead code: `hermesSkillPath` (skill.js), `vowelArticle` (helpers.js), `getBoolValue` (forms.js), unused `effectiveInstance` resolution + import (cli.js)
- Renamed unused args to `_x` per eslint config: `signal` ×2, `query` (helpers.js interactiveList)
- Removed useless assignments: `totalCount` init, `viewSysID` inits ×2
- Optional catch bindings for unused `err` ×2; comments for empty catches ×2
- Unnecessary `\\"` escapes in catalog.js option description
- Test cleanup: unused `opts`/dead `result` in docs.test.js

**Verification:** `npm run lint` → 0 problems; `npm test` → 213 pass, 0 fail.

Note: `catalog.js` computed `planID` (delivery/execution plan sys_id) but never included it in output — flagged, not changed. Happy to surface `execution_plan_id` if you want it shown.