### PR TITLE
fix(mutations): gate root eval and rest commands for read-only profiles

### DIFF
--- a/src/mutations.js
+++ b/src/mutations.js
@@ -62,8 +62,14 @@ export const MUTATION_COMMANDS = [
   ['catalog', 'create-item'],
   // Dev CRUD commands (root + `jsn dev` forms)
   ...DEV_CRUD_COMMANDS.flatMap(devCrudPaths),
-  // Dev eval (no sub-action)
+  // Dev eval (no sub-action) — both spellings must be gated:
+  // `jsn eval` (root) and legacy `jsn dev eval`
+  ['eval'],
   ['dev', 'eval'],
+  // Raw REST passthrough — can hit any endpoint with any method,
+  // so the whole command is a mutation surface on read-only profiles
+  ['rest'],
+  ['dev', 'rest'],
   // Scopes: create + set (root + dev forms)
   ['scopes', 'create'],
   ['scopes', 'set'],

--- a/test/mutations.test.js
+++ b/test/mutations.test.js
@@ -20,6 +20,17 @@ describe('mutations.js', () => {
     assert.strictEqual(isMutationCommand({ _: ['dev', 'eval'] }), true);
   });
 
+  // Read-only bypass regression (issue #143): root `jsn eval` and
+  // `jsn rest` were NOT in the registry — only the legacy dev forms were.
+  it('should detect root eval as mutation', () => {
+    assert.strictEqual(isMutationCommand({ _: ['eval'] }), true);
+  });
+
+  it('should detect rest as mutation in both forms', () => {
+    assert.strictEqual(isMutationCommand({ _: ['rest'] }), true);
+    assert.strictEqual(isMutationCommand({ _: ['dev', 'rest'] }), true);
+  });
+
   it('should not detect auth switch as mutation', () => {
     assert.strictEqual(isMutationCommand({ _: ['auth', 'switch', 'foo'] }), false);
   });


### PR DESCRIPTION
Closes #143 (finding #1).

## Problem

`MUTATION_COMMANDS` in `src/mutations.js` is the registry the read-only profile guard checks via `isMutationCommand()`, which matches exact-length command-path arrays. Two commands fell outside it:

- **`jsn eval`** is registered at root (`src/cli.js:360`, argv path `['eval']`, length 1) but the registry only listed `['dev','eval']` (length 2). The top-level, README-documented form was unprotected — a read-only profile could still run arbitrary server-side JS. Only the legacy `jsn dev eval` alias was gated.
- **`jsn rest`** was missing entirely — `jsn rest -X DELETE --table incident --query "sys_id=..."` (or any POST/PUT/PATCH to any endpoint) sailed past a read-only profile.

## Fix

Added `['eval']`, `['rest']`, and `['dev','rest']` to the registry. `rest` is treated as a full mutation surface (it can hit any endpoint with any method), matching how the review recommended handling it.

## Tests

- `test/mutations.test.js`: root eval detected, rest detected in both spellings.
- Full suite: 231 pass, 0 fail (was 229/0 baseline + 2 new tests).
