### PR TITLE
feat(confirm): require confirmation on all deletes, per-instance opt-out

### DIFF
--- a/src/commands/_ticket.js
+++ b/src/commands/_ticket.js
@@ -1,7 +1,7 @@
 // Generic command builder for CRUD operations on a ServiceNow table
 // Used by incidents, changes, requests, tasks, and most dev subcommands
 
-import { getStringField, formatRecordForDisplay, buildQuerySuffix, resolveFieldsParam } from '../helpers.js';
+import { getStringField, formatRecordForDisplay, buildQuerySuffix, resolveFieldsParam, confirmDelete } from '../helpers.js';
 import { search } from '@inquirer/prompts';
 import { isTTY, FormatAuto } from '../output.js';
 
@@ -237,8 +237,10 @@ export function buildTicketCommands(table, displayName, alias, defaultColumns, s
         .command({
           command: 'delete <number>',
           describe: `Delete a ${displayName}`,
+          builder: (y) => y.option('force', { type: 'boolean', default: false, describe: 'Skip confirmation' }),
           handler: wrap(async (argv, app) => {
             const number = argv.number;
+            await confirmDelete(app, argv, `Delete ${displayName} ${number}`);
             const findParams = new URLSearchParams();
             findParams.set('sysparm_query', `number=${number}`);
             findParams.set('sysparm_limit', '1');

--- a/src/commands/auth.js
+++ b/src/commands/auth.js
@@ -57,6 +57,9 @@ export async function loginWizard(app, argv = {}) {
   if (argv['read-only']) {
     profile.read_only = true;
   }
+  if (argv['skip-confirmations']) {
+    profile.skip_confirmations = true;
+  }
 
   const authMethod = await ask('Authentication method (OAuth/Basic) [OAuth]: ');
   const useBasic = authMethod.toLowerCase().startsWith('b');
@@ -192,6 +195,11 @@ export function authCmd(wrap) {
               describe: 'Mark the created profile as read-only (blocks mutation commands)',
               type: 'boolean',
               default: false,
+            })
+            .option('skip-confirmations', {
+              describe: 'Skip delete confirmations on this profile (deletes run without prompting)',
+              type: 'boolean',
+              default: false,
             }),
           handler: wrap(async (argv, app) => {
             let instanceURL;
@@ -293,6 +301,7 @@ Find your instance URL in your browser's address bar when logged into ServiceNow
               auth_method: argv.password ? 'basic' : 'oauth',
               username: username || undefined,
               read_only: argv['read-only'] || undefined,
+              skip_confirmations: argv['skip-confirmations'] || undefined,
             };
 
             // Re-save OAuth credentials with username now that we have it,
@@ -405,6 +414,7 @@ Examples:
                 stale: daysSinceLastSeen > 7,
                 default: instance === defaultInstance,
                 read_only: profile.read_only || false,
+                skip_confirmations: profile.skip_confirmations || false,
               });
             }
 

--- a/src/commands/dev/_generic.js
+++ b/src/commands/dev/_generic.js
@@ -1,7 +1,6 @@
 // Generic dev subcommand builder for table-based CRUD
 
-import readline from 'node:readline';
-import { formatRecordForDisplay, getStringField, isHexString, parseDataArg } from '../../helpers.js';
+import { formatRecordForDisplay, getStringField, isHexString, parseDataArg, confirmDelete } from '../../helpers.js';
 import { getCurrentUser, getCurrentApplication } from '../../context.js';
 import { paginatedSearch } from '../../paginated-search.js';
 import { isTTY, FormatAuto } from '../../output.js';
@@ -308,17 +307,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
               }
             }
 
-            if (!argv.force && process.stdout.isTTY && process.stdin.isTTY) {
-              const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-              const answer = await new Promise((resolve) => {
-                rl.question(`Delete ${singular} '${recordName}'? (y/N): `, resolve);
-              });
-              rl.close();
-              const response = answer.trim().toLowerCase();
-              if (response !== 'y' && response !== 'yes') {
-                throw new Error('Deletion cancelled');
-              }
-            }
+            await confirmDelete(app, argv, `Delete ${singular} '${recordName}'`);
 
             await app.sdk.delete(table, sysID);
             app.ok({ name: recordName, sys_id: sysID, deleted: true }, { summary: `Deleted ${singular} '${recordName}'` });

--- a/src/commands/records.js
+++ b/src/commands/records.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, buildQuerySuffix, parseDataArg, getStringField, interactiveList, resolveFieldsParam, checkDerivedFields } from '../helpers.js';
+import { formatRecordForDisplay, buildQuerySuffix, parseDataArg, getStringField, interactiveList, resolveFieldsParam, checkDerivedFields, confirmDelete } from '../helpers.js';
 
 const tableDefaultColumns = {
   incident: ['number', 'short_description', 'priority', 'state', 'assigned_to'],
@@ -169,8 +169,10 @@ export function recordsCmd(wrap) {
           describe: 'Delete a record',
           builder: (y) => y
             .option('table', { type: 'string', demandOption: true, describe: 'Table name' })
-            .option('sys-id', { type: 'string', demandOption: true, describe: 'Record sys_id' }),
+            .option('sys-id', { type: 'string', demandOption: true, describe: 'Record sys_id' })
+            .option('force', { type: 'boolean', default: false, describe: 'Skip confirmation' }),
           handler: wrap(async (argv, app) => {
+            await confirmDelete(app, argv, `Delete record from ${argv.table} (${argv['sys-id']})`);
             await app.sdk.delete(argv.table, argv['sys-id']);
             app.ok({ message: 'Record deleted', table: argv.table, sys_id: argv['sys-id'] }, { summary: `Deleted record from ${argv.table}` });
           }),

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,8 +1,47 @@
 // Shared helper utilities
 
 import fs from 'node:fs';
+import readline from 'node:readline';
 import { paginatedSearch } from './paginated-search.js';
 import { isTTY, FormatAuto } from './output.js';
+import { getActiveProfile } from './config.js';
+
+/**
+ * Confirm a destructive action before executing.
+ *
+ * Default posture is ASK: interactive terminals get a y/N prompt;
+ * non-interactive invocation (pipes, scripts, AI agents) is rejected
+ * unless --force is passed. A profile can opt out entirely with the
+ * per-instance `skip_confirmations` flag (set via `auth login
+ * --skip-confirmations`).
+ *
+ * @param {object} app — app instance (reads active profile from app.config)
+ * @param {object} argv — parsed args (checks argv.force)
+ * @param {string} question — e.g. `Delete incident INC0010001?`
+ * @returns {Promise<boolean>} true when the action may proceed
+ * @throws when confirmation is required but denied/unavailable
+ */
+export async function confirmDelete(app, argv, question) {
+  const profile = getActiveProfile(app.config);
+  if (profile?.skip_confirmations === true) return true;
+  if (argv.force) return true;
+  if (isTTY(process.stdout) && isTTY(process.stdin)) {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise((resolve) => {
+      rl.question(`${question} (y/N): `, resolve);
+    });
+    rl.close();
+    const response = answer.trim().toLowerCase();
+    if (response !== 'y' && response !== 'yes') {
+      throw new Error('Deletion cancelled');
+    }
+    return true;
+  }
+  throw new Error(
+    `${question} — confirmation required. Pass --force to skip, or set skip_confirmations on the profile to disable prompts.`
+  );
+}
+
 
 export function getStringField(record, field) {
   if (!record || typeof record !== 'object') return '';

--- a/src/output.js
+++ b/src/output.js
@@ -200,12 +200,15 @@ export class OutputWriter {
           // Show lock icon for read-only profiles
           const lockIcon = p.read_only ? ' 🔒' : '';
 
+          // Show confirmations-off badge for skip_confirmations profiles
+          const confirmBadge = p.skip_confirmations ? ' ⚡' : '';
+
           if (p.name) {
-            this.writer.write(`${prefix}${authIcon} ${p.name} — ${p.instance}${lockIcon}${verifiedStr}${staleStr}\n`);
+            this.writer.write(`${prefix}${authIcon} ${p.name} — ${p.instance}${lockIcon}${confirmBadge}${verifiedStr}${staleStr}\n`);
           } else if (p.username) {
-            this.writer.write(`${prefix}${authIcon} ${p.instance} (as ${p.username})${lockIcon}${verifiedStr}${staleStr}\n`);
+            this.writer.write(`${prefix}${authIcon} ${p.instance} (as ${p.username})${lockIcon}${confirmBadge}${verifiedStr}${staleStr}\n`);
           } else {
-            this.writer.write(`${prefix}${authIcon} ${p.instance}${lockIcon}${verifiedStr}${staleStr}\n`);
+            this.writer.write(`${prefix}${authIcon} ${p.instance}${lockIcon}${confirmBadge}${verifiedStr}${staleStr}\n`);
           }
         }
       }

--- a/test/confirm-delete.test.js
+++ b/test/confirm-delete.test.js
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+describe('confirmDelete', () => {
+  let confirmDelete;
+
+  const makeApp = (profile) => ({
+    config: {
+      activeProfile: 'test',
+      defaultProfile: 'test',
+      profiles: { test: profile || {} },
+    },
+  });
+
+  it('allows when profile has skip_confirmations', async () => {
+    ({ confirmDelete } = await import('../src/helpers.js'));
+    const ok = await confirmDelete(makeApp({ skip_confirmations: true }), {}, 'Delete incident INC001');
+    assert.strictEqual(ok, true);
+  });
+
+  it('allows when --force is passed (no profile flag)', async () => {
+    ({ confirmDelete } = await import('../src/helpers.js'));
+    const ok = await confirmDelete(makeApp({}), { force: true }, 'Delete incident INC001');
+    assert.strictEqual(ok, true);
+  });
+
+  it('rejects non-interactive deletes without --force (default ask)', async () => {
+    ({ confirmDelete } = await import('../src/helpers.js'));
+    await assert.rejects(
+      () => confirmDelete(makeApp({}), {}, 'Delete incident INC001'),
+      /confirmation required.*--force/s
+    );
+  });
+
+  it('rejects even when --force is absent but read_only is set (flags are independent)', async () => {
+    ({ confirmDelete } = await import('../src/helpers.js'));
+    await assert.rejects(
+      () => confirmDelete(makeApp({ read_only: true }), {}, 'Delete incident INC001'),
+      /confirmation required.*--force/s
+    );
+  });
+
+  it('allows when both flags are set', async () => {
+    ({ confirmDelete } = await import('../src/helpers.js'));
+    const ok = await confirmDelete(makeApp({ skip_confirmations: true }), { force: true }, 'Delete incident INC001');
+    assert.strictEqual(ok, true);
+  });
+
+  it('handles missing active profile gracefully (throws, does not crash)', async () => {
+    ({ confirmDelete } = await import('../src/helpers.js'));
+    await assert.rejects(
+      () => confirmDelete({ config: { profiles: {} } }, {}, 'Delete incident INC001'),
+      /confirmation required.*--force/s
+    );
+  });
+});


### PR DESCRIPTION
Closes #143 (finding #4).

## Problem

Deletes had three different, all-weak postures:

- `_ticket.js` (`incidents/changes/requests/tasks/tickets delete`) — **zero** confirmation, no `--force`.
- `records.js` (`records delete --table X --sys-id Y`) — **zero** confirmation.
- `_generic.js` (dev CRUD) — prompted only `if (!argv.force && isTTY && isTTY)`. In any non-interactive context (piped output, script, AI agent) that's false and it deleted without needing `--force`.

`AGENTS.md` told agents to "always verify with the user before running mutation commands" — a documentation-level convention with no code enforcement.

## Design (agreed with maintainer)

**Deletes default to ASK everywhere:**
- Interactive terminal → y/N prompt
- Non-interactive (pipes, scripts, agents) → rejected unless `--force` is passed
- Per-instance opt-out: `skip_confirmations` profile flag (set via `jsn auth login --skip-confirmations`, same pattern as `read_only`), shown as a ⚡ badge in `jsn auth status`

## Changes

- New shared `confirmDelete(app, argv, question)` helper in `src/helpers.js` — one code path for all three delete implementations
- Wired into `_ticket.js`, `records.js`, `_generic.js` delete handlers; `--force` added where it was missing
- `--skip-confirmations` option on `auth login` (login handler + setup wizard), persisted on the profile, surfaced in `auth status` (JSON field + ⚡ badge)

## Tests

- New `test/confirm-delete.test.js`: skip flag allows, `--force` allows, non-TTY without `--force` rejects, flags are independent of `read_only`, missing profile handled gracefully.
- Full suite: 235 pass, 0 fail.
