### PR TITLE
fix(security): sanitize key parts, no-shell keyring calls, validate exact-match queries

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -7,7 +7,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { password as passwordPrompt } from '@inquirer/prompts';
 import { globalConfigDir, normalizeInstanceURL } from './config.js';
 import { errAuth } from './errors.js';
@@ -15,11 +15,26 @@ import { errAuth } from './errors.js';
 // ─── Credential key helpers ───
 
 /**
+ * Sanitize an instance URL into a filesystem/arg-safe key part.
+ *
+ * Whitelist approach (issue #143 findings #2/#3): first map the `://`
+ * protocol separator to `_` exactly as the Go version's encoding does
+ * (so existing keyring keys like `https_dev437538.service-now.com` keep
+ * matching), then drop everything outside [a-zA-Z0-9._-]. Blacklist
+ * stripping of just `/` and `:` left quotes, `$()`, backticks, `;`,
+ * spaces, and backslashes — which broke out of double-quoted shell args
+ * in keyring calls and, on Windows, out of path.join() credential dirs.
+ */
+export function sanitizeKeyPart(instance) {
+  return instance.replace(/:\/\//g, '_').replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+/**
  * Build a compound key for credential storage: <username>@<instance>
  * When username is omitted (legacy), just the normalized instance URL is used.
  */
 function credKey(instance, username) {
-  const normalized = instance.replace(/:\/\//g, '_').replace(/\//g, '_').replace(/:/g, '_');
+  const normalized = sanitizeKeyPart(instance);
   if (!username) return normalized;
   return `${username.replace(/[^a-zA-Z0-9._@-]/g, '_')}@${normalized}`;
 }
@@ -29,7 +44,7 @@ function credKey(instance, username) {
 function pkceStatePath(instance) {
   const dir = path.join(globalConfigDir(), 'pkce');
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  const filename = instance.replace(/:\/\//g, '_').replace(/\//g, '_').replace(/:/g, '_') + '.json';
+  const filename = sanitizeKeyPart(instance) + '.json';
   return path.join(dir, filename);
 }
 
@@ -133,8 +148,11 @@ function buildAuthURL(instanceURL, clientID, pkce) {
 
 function keyringLookup(key) {
   try {
-    const result = execSync(
-      `secret-tool lookup ${KEYRING_ATTR_SERVICE} ${KEYRING_SERVICE} ${KEYRING_ATTR_USERNAME} "${key}"`,
+    // execFileSync with an arg array — no shell, so `key` can never
+    // break out into command injection (issue #143 finding #2).
+    const result = execFileSync(
+      'secret-tool',
+      ['lookup', KEYRING_ATTR_SERVICE, KEYRING_SERVICE, KEYRING_ATTR_USERNAME, key],
       { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' }
     );
     const trimmed = result.trim();
@@ -157,9 +175,10 @@ function keyringLookup(key) {
 
 function keyringStore(key, creds) {
   try {
-    execSync(
-      `secret-tool store --label="Password for '${key}' on '${KEYRING_SERVICE}'" ` +
-      `${KEYRING_ATTR_SERVICE} ${KEYRING_SERVICE} ${KEYRING_ATTR_USERNAME} "${key}"`,
+    execFileSync(
+      'secret-tool',
+      ['store', `--label=Password for '${key}' on '${KEYRING_SERVICE}'`,
+        KEYRING_ATTR_SERVICE, KEYRING_SERVICE, KEYRING_ATTR_USERNAME, key],
       { stdio: ['pipe', 'ignore', 'ignore'], input: JSON.stringify(creds) }
     );
     return true;
@@ -170,8 +189,9 @@ function keyringStore(key, creds) {
 
 function keyringDelete(key) {
   try {
-    execSync(
-      `secret-tool clear ${KEYRING_ATTR_SERVICE} ${KEYRING_SERVICE} ${KEYRING_ATTR_USERNAME} "${key}"`,
+    execFileSync(
+      'secret-tool',
+      ['clear', KEYRING_ATTR_SERVICE, KEYRING_SERVICE, KEYRING_ATTR_USERNAME, key],
       { stdio: 'ignore' }
     );
   } catch {

--- a/src/commands/_ticket.js
+++ b/src/commands/_ticket.js
@@ -1,7 +1,7 @@
 // Generic command builder for CRUD operations on a ServiceNow table
 // Used by incidents, changes, requests, tasks, and most dev subcommands
 
-import { getStringField, formatRecordForDisplay, buildQuerySuffix, resolveFieldsParam, confirmDelete } from '../helpers.js';
+import { getStringField, formatRecordForDisplay, buildQuerySuffix, resolveFieldsParam, confirmDelete, assertSafeExactMatch } from '../helpers.js';
 import { search } from '@inquirer/prompts';
 import { isTTY, FormatAuto } from '../output.js';
 
@@ -86,6 +86,7 @@ export function buildTicketCommands(table, displayName, alias, defaultColumns, s
               }
 
               if (selectedNumber) {
+                assertSafeExactMatch(selectedNumber);
                 const showParams = new URLSearchParams();
                 showParams.set('sysparm_query', `number=${selectedNumber}`);
                 showParams.set('sysparm_display_value', 'all');
@@ -161,6 +162,7 @@ export function buildTicketCommands(table, displayName, alias, defaultColumns, s
           describe: `Show a specific ${displayName}`,
           handler: wrap(async (argv, app) => {
             const number = argv.number;
+            assertSafeExactMatch(number);
             const params = new URLSearchParams();
             params.set('sysparm_query', `number=${number}`);
             params.set('sysparm_display_value', 'all');
@@ -216,6 +218,7 @@ export function buildTicketCommands(table, displayName, alias, defaultColumns, s
             .option('data', { type: 'string', demandOption: true, describe: 'JSON data to update' }),
           handler: wrap(async (argv, app) => {
             const number = argv.number;
+            assertSafeExactMatch(number);
             const recordData = JSON.parse(argv.data);
             const findParams = new URLSearchParams();
             findParams.set('sysparm_query', `number=${number}`);
@@ -241,6 +244,7 @@ export function buildTicketCommands(table, displayName, alias, defaultColumns, s
           handler: wrap(async (argv, app) => {
             const number = argv.number;
             await confirmDelete(app, argv, `Delete ${displayName} ${number}`);
+            assertSafeExactMatch(number);
             const findParams = new URLSearchParams();
             findParams.set('sysparm_query', `number=${number}`);
             findParams.set('sysparm_limit', '1');

--- a/src/commands/catalog.js
+++ b/src/commands/catalog.js
@@ -1,4 +1,4 @@
-import { getStringField, interactiveList } from '../helpers.js';
+import { getStringField, interactiveList, assertSafeExactMatch } from '../helpers.js';
 
 export function catalogCmd(wrap) {
   return {
@@ -150,6 +150,7 @@ export function catalogCmd(wrap) {
             app.requireInstance();
             let id = argv.id;
             if (!/^[a-f0-9]{32}$/i.test(id)) {
+              assertSafeExactMatch(id);
               const p = new URLSearchParams();
               p.set('sysparm_query', `name=${id}`);
               p.set('sysparm_limit', '1');

--- a/src/commands/dev/_generic.js
+++ b/src/commands/dev/_generic.js
@@ -1,6 +1,6 @@
 // Generic dev subcommand builder for table-based CRUD
 
-import { formatRecordForDisplay, getStringField, isHexString, parseDataArg, confirmDelete } from '../../helpers.js';
+import { formatRecordForDisplay, getStringField, isHexString, parseDataArg, confirmDelete, assertSafeExactMatch } from '../../helpers.js';
 import { getCurrentUser, getCurrentApplication } from '../../context.js';
 import { paginatedSearch } from '../../paginated-search.js';
 import { isTTY, FormatAuto } from '../../output.js';
@@ -149,6 +149,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
 
             if (selectedName) {
               const recordName = typeof selectedName === 'object' ? selectedName.value : selectedName;
+              assertSafeExactMatch(recordName);
               const showParams = new URLSearchParams();
               showParams.set('sysparm_query', `name=${recordName}`);
               showParams.set('sysparm_display_value', 'all');
@@ -201,6 +202,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
         handler: wrap(async (argv, app) => {
           const id = argv.identifier;
           const queryField = isHexString(id) && id.length === 32 ? 'sys_id' : 'name';
+          assertSafeExactMatch(id);
           const params = new URLSearchParams();
           params.set('sysparm_query', `${queryField}=${id}`);
           params.set('sysparm_limit', '1');
@@ -258,6 +260,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
           handler: wrap(async (argv, app) => {
             const id = argv.identifier;
             const queryField = isHexString(id) && id.length === 32 ? 'sys_id' : 'name';
+            assertSafeExactMatch(id);
             const findParams = new URLSearchParams();
             findParams.set('sysparm_query', `${queryField}=${id}`);
             findParams.set('sysparm_limit', '1');
@@ -288,6 +291,7 @@ export function buildDevCmd(name, table, aliases, defaultColumns, wrap, opts = {
           handler: wrap(async (argv, app) => {
             const id = argv.identifier;
             const queryField = isHexString(id) && id.length === 32 ? 'sys_id' : 'name';
+            assertSafeExactMatch(id);
             const findParams = new URLSearchParams();
             findParams.set('sysparm_query', `${queryField}=${id}`);
             findParams.set('sysparm_limit', '1');

--- a/src/commands/grouproles.js
+++ b/src/commands/grouproles.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, getStringField, resolveFieldsParam } from '../helpers.js';
+import { formatRecordForDisplay, getStringField, resolveFieldsParam, assertSafeExactMatch } from '../helpers.js';
 
 export function groupRolesCmd(wrap) {
   return {
@@ -42,6 +42,8 @@ export function groupRolesCmd(wrap) {
           handler: wrap(async (argv, app) => {
             const groupName = argv.group;
             const roleName = argv.role;
+            assertSafeExactMatch(groupName);
+            assertSafeExactMatch(roleName);
 
             // Resolve group sys_id
             const isGroupSysID = groupName.length === 32 && /^[0-9a-fA-F]+$/.test(groupName);
@@ -100,6 +102,8 @@ export function groupRolesCmd(wrap) {
           handler: wrap(async (argv, app) => {
             const groupName = argv.group;
             const roleName = argv.role;
+            assertSafeExactMatch(groupName);
+            assertSafeExactMatch(roleName);
 
             // Resolve group sys_id
             const isGroupSysID = groupName.length === 32 && /^[0-9a-fA-F]+$/.test(groupName);

--- a/src/commands/groups.js
+++ b/src/commands/groups.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, getStringField, interactiveList, resolveFieldsParam } from '../helpers.js';
+import { formatRecordForDisplay, getStringField, interactiveList, resolveFieldsParam, assertSafeExactMatch } from '../helpers.js';
 
 export function groupsCmd(wrap) {
   return {
@@ -72,6 +72,7 @@ export function groupsCmd(wrap) {
           describe: 'Show a group by name or sys_id',
           handler: wrap(async (argv, app) => {
             const id = argv.name;
+            assertSafeExactMatch(id);
             const isSysID = id.length === 32 && /^[0-9a-fA-F]+$/.test(id);
             const params = new URLSearchParams();
             params.set('sysparm_query', isSysID ? `sys_id=${id}` : `name=${id}`);
@@ -117,6 +118,7 @@ export function groupsCmd(wrap) {
             .option('data', { type: 'string', demandOption: true, describe: 'JSON data to update' }),
           handler: wrap(async (argv, app) => {
             const id = argv.name;
+            assertSafeExactMatch(id);
             const recordData = JSON.parse(argv.data);
             const isSysID = id.length === 32 && /^[0-9a-fA-F]+$/.test(id);
             const params = new URLSearchParams();
@@ -142,6 +144,7 @@ export function groupsCmd(wrap) {
           describe: 'Delete a group by name or sys_id',
           handler: wrap(async (argv, app) => {
             const id = argv.name;
+            assertSafeExactMatch(id);
             const isSysID = id.length === 32 && /^[0-9a-fA-F]+$/.test(id);
             const params = new URLSearchParams();
             params.set('sysparm_query', isSysID ? `sys_id=${id}` : `name=${id}`);

--- a/src/commands/records.js
+++ b/src/commands/records.js
@@ -115,6 +115,7 @@ export function recordsCmd(wrap) {
             .option('sys-id', { type: 'string', demandOption: true, describe: 'Record sys_id' })
             .option('columns', { alias: ['c', 'fields'], type: 'string', describe: 'Comma-separated columns (e.g. "number,short_description")' }),
           handler: wrap(async (argv, app) => {
+            assertSafeExactMatch(argv['sys-id']);
             const params = new URLSearchParams();
             params.set('sysparm_query', `sys_id=${argv['sys-id']}`);
             params.set('sysparm_limit', '1');

--- a/src/commands/requests.js
+++ b/src/commands/requests.js
@@ -1,5 +1,5 @@
 import { buildTicketCommands } from './_ticket.js';
-import { getStringField } from '../helpers.js';
+import { getStringField, assertSafeExactMatch } from '../helpers.js';
 
 const requestDefaultColumns = ['number', 'short_description', 'stage', 'assigned_to'];
 
@@ -25,6 +25,7 @@ export function requestsCmd(wrap) {
 
 async function enrichedShowHandler(argv, app) {
   const number = argv.number;
+  assertSafeExactMatch(number);
   const params = new URLSearchParams();
   params.set('sysparm_query', `number=${number}`);
   params.set('sysparm_display_value', 'all');

--- a/src/commands/tickets.js
+++ b/src/commands/tickets.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, getStringField, buildQuerySuffix, resolveFieldsParam } from '../helpers.js';
+import { formatRecordForDisplay, getStringField, buildQuerySuffix, resolveFieldsParam, assertSafeExactMatch } from '../helpers.js';
 
 export function ticketsCmd(wrap) {
   return {
@@ -60,6 +60,7 @@ export function ticketsCmd(wrap) {
           aliases: ['get'],
           describe: 'Show a ticket',
           handler: wrap(async (argv, app) => {
+            assertSafeExactMatch(argv.number);
             const params = new URLSearchParams();
             params.set('sysparm_query', `number=${argv.number}`);
             params.set('sysparm_limit', '1');
@@ -87,6 +88,7 @@ export function ticketsCmd(wrap) {
           builder: (y) => y.option('data', { type: 'string', demandOption: true, describe: 'JSON fields (e.g. \'{"state":"2","priority":"1"}\')' }),
           handler: wrap(async (argv, app) => {
             const recordData = JSON.parse(argv.data);
+            assertSafeExactMatch(argv.number);
             const findParams = new URLSearchParams();
             findParams.set('sysparm_query', `number=${argv.number}`);
             findParams.set('sysparm_limit', '1');
@@ -103,6 +105,7 @@ export function ticketsCmd(wrap) {
           command: 'delete <number>',
           describe: 'Delete a ticket',
           handler: wrap(async (argv, app) => {
+            assertSafeExactMatch(argv.number);
             const findParams = new URLSearchParams();
             findParams.set('sysparm_query', `number=${argv.number}`);
             findParams.set('sysparm_limit', '1');

--- a/src/commands/users.js
+++ b/src/commands/users.js
@@ -1,4 +1,4 @@
-import { formatRecordForDisplay, getStringField, interactiveList, resolveFieldsParam } from '../helpers.js';
+import { formatRecordForDisplay, getStringField, interactiveList, resolveFieldsParam, assertSafeExactMatch } from '../helpers.js';
 
 export function usersCmd(wrap) {
   return {
@@ -57,6 +57,7 @@ export function usersCmd(wrap) {
           describe: 'Show a user by user_name or sys_id',
           handler: wrap(async (argv, app) => {
             const id = argv.identifier;
+            assertSafeExactMatch(id);
             const isSysID = id.length === 32 && /^[0-9a-fA-F]+$/.test(id);
             const params = new URLSearchParams();
             params.set('sysparm_query', isSysID ? `sys_id=${id}` : `user_name=${id}`);
@@ -104,6 +105,7 @@ export function usersCmd(wrap) {
             .option('data', { type: 'string', demandOption: true, describe: 'JSON data to update' }),
           handler: wrap(async (argv, app) => {
             const id = argv.identifier;
+            assertSafeExactMatch(id);
             const recordData = JSON.parse(argv.data);
             const isSysID = id.length === 32 && /^[0-9a-fA-F]+$/.test(id);
             const params = new URLSearchParams();
@@ -130,6 +132,7 @@ export function usersCmd(wrap) {
           describe: 'Delete a user by user_name or sys_id',
           handler: wrap(async (argv, app) => {
             const id = argv.identifier;
+            assertSafeExactMatch(id);
             const isSysID = id.length === 32 && /^[0-9a-fA-F]+$/.test(id);
             const params = new URLSearchParams();
             params.set('sysparm_query', isSysID ? `sys_id=${id}` : `user_name=${id}`);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -113,6 +113,29 @@ export function resolveFieldsParam(columns) {
   return ['sys_id', ...columns].join(',');
 }
 
+// ServiceNow encoded-query metacharacters. In sysparm_query, `^` is the
+// AND-separator (^OR starts an OR clause), `= < > ~ !` are operators,
+// and `,` is used by IN lists. An identifier containing any of these
+// silently broadens an exact-match lookup — with sysparm_limit=1 the
+// wrong record wins (issue #143 finding #5). Exact-match identifiers
+// (numbers, sys_ids, names) never legitimately contain them.
+const QUERY_METACHARS = /[\^=<>~!,]/;
+
+/**
+ * Validate that an identifier is safe to use in an exact-match encoded
+ * query (field=value). Throws when the value contains characters that
+ * would change the query semantics.
+ * @param {string} value — identifier (number, sys_id, name)
+ */
+export function assertSafeExactMatch(value) {
+  if (value && QUERY_METACHARS.test(value)) {
+    throw new Error(
+      `Unsafe identifier for exact-match lookup: contains ServiceNow query characters (^ = < > ~ ! ,). ` +
+      `Refusing to build a query that could match more than the named record.`
+    );
+  }
+}
+
 /**
  * Shared interactive list helper with search-as-you-type.
  * All list commands that want an interactive TTY picker should use this.

--- a/src/records/inspect.js
+++ b/src/records/inspect.js
@@ -1,4 +1,4 @@
-import { isHexString, getStringField } from '../helpers.js';
+import { isHexString, getStringField, assertSafeExactMatch } from '../helpers.js';
 
 export async function resolveIdentifier(app, table, identifier) {
   // If it looks like a sys_id (32 hex chars), use it directly
@@ -7,6 +7,7 @@ export async function resolveIdentifier(app, table, identifier) {
   }
 
   // Otherwise, assume it's a record number — query the table
+  assertSafeExactMatch(identifier);
   const params = new URLSearchParams();
   params.set('sysparm_query', `number=${identifier}`);
   params.set('sysparm_limit', '1');

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+describe('sanitizeKeyPart', () => {
+  let sanitizeKeyPart;
+
+  it('preserves existing keyring key format (backward compat)', async () => {
+    ({ sanitizeKeyPart } = await import('../src/auth.js'));
+    // The exact encoding the Go version uses — must NOT change, or stored
+    // credentials become unreachable.
+    assert.strictEqual(
+      sanitizeKeyPart('https://dev437538.service-now.com'),
+      'https_dev437538.service-now.com'
+    );
+  });
+
+  it('strips shell metacharacters (issue #143 finding #2)', async () => {
+    ({ sanitizeKeyPart } = await import('../src/auth.js'));
+    const out = sanitizeKeyPart('https://foo.com"; touch /tmp/pwned #');
+    // The whitelist only keeps [a-zA-Z0-9._-]; shell-active chars and
+    // spaces must all be gone, so the value can't break out of a shell arg.
+    assert.ok(!/["'$`;()\s]/.test(out), `still contains shell metachars: ${out}`);
+  });
+
+  it('strips backslashes (issue #143 finding #3 — Windows path traversal)', async () => {
+    ({ sanitizeKeyPart } = await import('../src/auth.js'));
+    const out = sanitizeKeyPart('https://foo.com\\..\\..\\..\\evil');
+    // No path separators (forward OR backslash) survive, so `..` can
+    // never act as a traversal component in path.join on any platform.
+    assert.ok(!/[\\/]/.test(out), `path separator survived: ${out}`);
+  });
+
+  it('keeps dots and dashes for real instance hosts', async () => {
+    ({ sanitizeKeyPart } = await import('../src/auth.js'));
+    assert.strictEqual(
+      sanitizeKeyPart('https://dev-437538.service-now.com'),
+      'https_dev-437538.service-now.com'
+    );
+  });
+});
+
+describe('assertSafeExactMatch', () => {
+  let assertSafeExactMatch;
+
+  it('allows normal identifiers', async () => {
+    ({ assertSafeExactMatch } = await import('../src/helpers.js'));
+    assert.doesNotThrow(() => assertSafeExactMatch('INC0010001'));
+    assert.doesNotThrow(() => assertSafeExactMatch('a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e'));
+    assert.doesNotThrow(() => assertSafeExactMatch('My_Script-Include.v2'));
+  });
+
+  it('rejects ^ (ServiceNow query AND separator)', async () => {
+    ({ assertSafeExactMatch } = await import('../src/helpers.js'));
+    assert.throws(() => assertSafeExactMatch('INC001^state=1'), /Unsafe identifier/);
+    assert.throws(() => assertSafeExactMatch('INC001^ORnumber=INC002'), /Unsafe identifier/);
+  });
+
+  it('rejects other query operators and IN-list commas', async () => {
+    ({ assertSafeExactMatch } = await import('../src/helpers.js'));
+    assert.throws(() => assertSafeExactMatch('x=1'), /Unsafe identifier/);
+    assert.throws(() => assertSafeExactMatch('a<b'), /Unsafe identifier/);
+    assert.throws(() => assertSafeExactMatch('a>b'), /Unsafe identifier/);
+    assert.throws(() => assertSafeExactMatch('a~b'), /Unsafe identifier/);
+    assert.throws(() => assertSafeExactMatch('a!b'), /Unsafe identifier/);
+    assert.throws(() => assertSafeExactMatch('a,b'), /Unsafe identifier/);
+  });
+
+  it('allows empty/undefined values (callers decide what empty means)', async () => {
+    ({ assertSafeExactMatch } = await import('../src/helpers.js'));
+    assert.doesNotThrow(() => assertSafeExactMatch(''));
+    assert.doesNotThrow(() => assertSafeExactMatch(undefined));
+  });
+});


### PR DESCRIPTION
Closes #143 (findings #2, #3, #5).

## Problem

Three security issues from the code review, all rooted in blacklist-style sanitization written once and reused where whitelists were needed:

**#2 Shell command injection** — `keyringLookup`/`keyringStore`/`keyringDelete` in `src/auth.js` shelled out to `secret-tool` via string-interpolated `execSync`. `credKey()` only stripped `://`, `/`, `:` — quotes, `$()`, backticks, `;`, and spaces survived into a double-quoted shell arg. `SERVICENOW_INSTANCE_URL` from CI env or agent-constructed values made this exploitable.

**#3 Path traversal on Windows** — same `credKey()` + `pkceStatePath()` stripped forward slashes but never backslashes. On Windows, `path.join` treats `\` as a separator, so an instance value with `\..\..\..\` could write credential/PKCE JSON outside `~/.config/servicenow/credentials/`.

**#5 Encoded-query injection** — identifiers were concatenated raw into `sysparm_query` (`number=${number}`, `${queryField}=${id}`). A value containing `^` (ServiceNow's AND separator) or `^OR` silently broadened the match; with `sysparm_limit=1` the wrong record won. Combined with the old no-confirmation deletes, an identifier from untrusted data could delete a record the caller never named.

## Fix

- **New `sanitizeKeyPart()`** — whitelist `[a-zA-Z0-9._-]` applied AFTER mapping `://` → `_`. This preserves the exact Go-compatible key encoding (`https_dev437538.service-now.com` keys keep matching — no credential orphaning) while killing everything else.
- **`execFileSync` for all keyring calls** — arg array, no shell, so the key can never break out.
- **New `assertSafeExactMatch()`** — rejects identifiers containing ServiceNow query metacharacters (`^ = < > ~ ! ,`), wired into every exact-match lookup: `_ticket.js`, `_generic.js`, `tickets.js`, `users.js`, `groups.js`, `grouproles.js`, `catalog.js`, `records.js`/`inspect.js`, `requests.js`.

## Tests

- New `test/security.test.js`: sanitizer backward-compat + shell/traversal stripping; validator allow/reject sets.
- Full unit suite: 237 pass, 0 fail.
- **E2E against live PDI** (`JSN_INTEGRATION_TESTS=true`): 34/34 pass. Live smoke: normal `incidents list` works (auth + keyring intact), `incidents show 'INC0010001^state=1'` correctly rejected.
